### PR TITLE
Change the default API URLs

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,19 +38,19 @@ func TestEndpoints_Resolve(t *testing.T) {
 			desc:                "default experiments",
 			experimentsEndpoint: *experimentsEndpoint, // Default value hack
 			endpoint:            "/experiments/",
-			expected:            "https://api.carbonrelay.io/v1/experiments/",
+			expected:            "https://api.stormforge.io/v1/experiments/",
 		},
 		{
 			desc:                "default experiment",
 			experimentsEndpoint: *experimentsEndpoint, // Default value hack
 			endpoint:            "/experiments/foo_bar",
-			expected:            "https://api.carbonrelay.io/v1/experiments/foo_bar",
+			expected:            "https://api.stormforge.io/v1/experiments/foo_bar",
 		},
 		{
 			desc:                "default trials",
 			experimentsEndpoint: *experimentsEndpoint, // Default value hack
 			endpoint:            "/experiments/foo_bar/trials/",
-			expected:            "https://api.carbonrelay.io/v1/experiments/foo_bar/trials/",
+			expected:            "https://api.stormforge.io/v1/experiments/foo_bar/trials/",
 		},
 		{
 			desc:                "explicit endpoint",

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -67,10 +67,10 @@ func defaultServerRoots(env string, srv *Server) error {
 	// The environment corresponds to deployment details of the proprietary backend
 	switch env {
 	case "production":
-		defaultString(&srv.Identifier, "https://api.carbonrelay.io/v1/")
+		defaultString(&srv.Identifier, "https://api.stormforge.io/v1/")
 		defaultString(&srv.Authorization.Issuer, "https://auth.carbonrelay.io/")
 	case "development":
-		defaultString(&srv.Identifier, "https://api.carbonrelay.dev/v1/")
+		defaultString(&srv.Identifier, "https://api.stormforge.dev/v1/")
 		defaultString(&srv.Authorization.Issuer, "https://auth.carbonrelay.dev/")
 	default:
 		return fmt.Errorf("unknown environment: '%s'", env)


### PR DESCRIPTION
This just changes the default URLs for the API. Currently the API is hosted at both the old and new location so we should be OK during the transition period.