### PR TITLE
Migrate config file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,8 +98,8 @@ func (rsc *RedSkyConfig) Write() error {
 		return nil
 	}
 
-	f := file{}
-	if err := f.read(rsc.Filename); err != nil {
+	f := file{filename: rsc.Filename}
+	if err := f.read(); err != nil {
 		return err
 	}
 
@@ -109,7 +109,7 @@ func (rsc *RedSkyConfig) Write() error {
 		}
 	}
 
-	if err := f.write(rsc.Filename); err != nil {
+	if err := f.write(); err != nil {
 		return err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,12 +120,7 @@ func (rsc *RedSkyConfig) Write() error {
 // Merge combines the supplied data with what is already present in this client configuration; unlike Update, changes
 // will not be persisted on the next write
 func (rsc *RedSkyConfig) Merge(data *Config) {
-	mergeServers(&rsc.data, data.Servers)
-	mergeAuthorizations(&rsc.data, data.Authorizations)
-	mergeClusters(&rsc.data, data.Clusters)
-	mergeControllers(&rsc.data, data.Controllers)
-	mergeContexts(&rsc.data, data.Contexts)
-	mergeString(&rsc.data.CurrentContext, data.CurrentContext)
+	mergeConfig(&rsc.data, data)
 }
 
 // Reader returns a configuration reader for accessing information from the configuration
@@ -171,10 +166,10 @@ func (rsc *RedSkyConfig) Endpoints() (Endpoints, error) {
 	}
 
 	ep := Endpoints(make(map[string]*url.URL, 2))
-	if err := add(ep, "/experiments/", srv.RedSky.ExperimentsEndpoint); err != nil {
+	if err := add(ep, "/experiments/", srv.API.ExperimentsEndpoint); err != nil {
 		return nil, err
 	}
-	if err := add(ep, "/accounts/", srv.RedSky.AccountsEndpoint); err != nil {
+	if err := add(ep, "/accounts/", srv.API.AccountsEndpoint); err != nil {
 		return nil, err
 	}
 	return ep, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,7 +26,7 @@ import (
 func TestEndpoints_Resolve(t *testing.T) {
 	cfg := &RedSkyConfig{}
 	require.NoError(t, defaultLoader(cfg))
-	experimentsEndpoint := &cfg.data.Servers[0].Server.RedSky.ExperimentsEndpoint
+	experimentsEndpoint := &cfg.data.Servers[0].Server.API.ExperimentsEndpoint
 
 	cases := []struct {
 		desc                string

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -55,14 +55,14 @@ type Server struct {
 	// may be used to resolve ".well-known" locations, used as an authorization audience, or used as a common base URL
 	// when determining default endpoint addresses. The URL must not have any query or fragment components.
 	Identifier string `json:"identifier"`
-	// RedSky contains the Red Sky server metadata necessary to access this server
-	RedSky RedSkyServer `json:"redsky"`
+	// API contains the API server metadata necessary to access the programmatic interface.
+	API APIServer `json:"api"`
 	// Authorization contains the authorization server metadata necessary to access this server
 	Authorization AuthorizationServer `json:"authorization"`
 }
 
-// RedSkyServer is the API server metadata
-type RedSkyServer struct {
+// APIServer is the API server metadata
+type APIServer struct {
 	// ExperimentsEndpoint is the URL of the experiments endpoint
 	ExperimentsEndpoint string `json:"experiments_endpoint,omitempty"`
 	// AccountsEndpoint is the URL of the accounts endpoint
@@ -270,17 +270,17 @@ func (c *Credential) MarshalJSON() ([]byte, error) {
 // MarshalJSON omits empty structs
 func (srv *Server) MarshalJSON() ([]byte, error) {
 	type S Server
-	as := &srv.Authorization
+	az := &srv.Authorization
 	if (AuthorizationServer{}) == srv.Authorization {
-		as = nil
+		az = nil
 	}
-	rss := &srv.RedSky
-	if (RedSkyServer{}) == srv.RedSky {
-		rss = nil
+	api := &srv.API
+	if (APIServer{}) == srv.API {
+		api = nil
 	}
 	return json.Marshal(&struct {
 		*S
 		Authorization *AuthorizationServer `json:"authorization,omitempty"`
-		RedSky        *RedSkyServer        `json:"redsky,omitempty"`
-	}{S: (*S)(srv), Authorization: as, RedSky: rss})
+		API           *APIServer           `json:"api,omitempty"`
+	}{S: (*S)(srv), Authorization: az, API: api})
 }

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -27,10 +27,20 @@ func mergeString(s1 *string, s2 string) {
 
 // Merge elements
 
+func mergeConfig(c1, c2 *Config) {
+	mergeServers(c1, c2.Servers)
+	mergeAuthorizations(c1, c2.Authorizations)
+	mergeClusters(c1, c2.Clusters)
+	mergeControllers(c1, c2.Controllers)
+	mergeContexts(c1, c2.Contexts)
+	mergeString(&c1.CurrentContext, c2.CurrentContext)
+	mergeString(&c1.Environment, c2.Environment)
+}
+
 func mergeServer(s1, s2 *Server) {
 	mergeString(&s1.Identifier, s2.Identifier)
-	mergeString(&s1.RedSky.AccountsEndpoint, s2.RedSky.AccountsEndpoint)
-	mergeString(&s1.RedSky.ExperimentsEndpoint, s2.RedSky.ExperimentsEndpoint)
+	mergeString(&s1.API.AccountsEndpoint, s2.API.AccountsEndpoint)
+	mergeString(&s1.API.ExperimentsEndpoint, s2.API.ExperimentsEndpoint)
 	mergeString(&s1.Authorization.Issuer, s2.Authorization.Issuer)
 	mergeString(&s1.Authorization.AuthorizationEndpoint, s2.Authorization.AuthorizationEndpoint)
 	mergeString(&s1.Authorization.TokenEndpoint, s2.Authorization.TokenEndpoint)

--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -48,21 +48,16 @@ func migrationLoader(cfg *RedSkyConfig) error {
 
 	// This is _really_ legacy at this point, we may want to consider dropping support
 	filename := filepath.Join(os.Getenv("HOME"), ".redsky")
-	name := "default"
-
-	// Use the current cluster name as the default name for controller
-	cmd := exec.Command("kubectl", "config", "view", "--minify", "--output", "jsonpath={.clusters[0].name}")
-	if stdout, err := cmd.Output(); err == nil {
-		name = strings.TrimSpace(string(stdout))
-	}
-
 	lc, err := loadLegacyConfigFile(filename)
-	if err != nil {
+	if err != nil || lc == nil || len(lc.Manager.Environment) == 0 {
 		return err
 	}
 
-	if lc == nil || len(lc.Manager.Environment) == 0 {
-		return nil
+	// Use the current cluster name as the default name for controller
+	name := "default"
+	cmd := exec.Command("kubectl", "config", "view", "--minify", "--output", "jsonpath={.clusters[0].name}")
+	if stdout, err := cmd.Output(); err == nil {
+		name = strings.TrimSpace(string(stdout))
 	}
 
 	apply := func(cfg *Config) {

--- a/pkg/config/overrides.go
+++ b/pkg/config/overrides.go
@@ -55,7 +55,7 @@ func (o *overrideReader) Server(name string) (Server, error) {
 
 	if o.overrides.ServerIdentifier != "" {
 		mergeString(&srv.Identifier, o.overrides.ServerIdentifier)
-		srv.RedSky = RedSkyServer{}
+		srv.API = APIServer{}
 		srv.Authorization.RegistrationEndpoint = ""
 	}
 


### PR DESCRIPTION
This change moves the configuration file from `~/.config/redsky/config` to `~/.config/stormforge/config`. The rename will happen automatically the first time the configuration is loaded.

Also, I noticed we are making an extra call to `kubectl` that can be avoided.