### PR TITLE
Revocation fixes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -245,17 +245,12 @@ func (ri *RevocationInformation) String() string {
 	return ri.authorizationName
 }
 
-// RemoveAuthorization returns a configuration change to remove the authorization associated with the revocation information
+// RemoveAuthorization returns a configuration change to clear the credentials for an authorization.
 func (ri *RevocationInformation) RemoveAuthorization() Change {
 	return func(cfg *Config) error {
-		for i := range cfg.Contexts {
-			if cfg.Contexts[i].Context.Authorization == ri.authorizationName {
-				cfg.Contexts[i].Context.Authorization = ""
-			}
-		}
 		for i := range cfg.Authorizations {
 			if cfg.Authorizations[i].Name == ri.authorizationName {
-				cfg.Authorizations = append(cfg.Authorizations[:i], cfg.Authorizations[i+1:]...)
+				cfg.Authorizations[i].Authorization.Credential = Credential{}
 				return nil
 			}
 		}


### PR DESCRIPTION
This includes a fix and a change:

The change is that we currently allow revocation information to be collected for any authorization. This gives callers too much flexibility when the value they will pass it _should_ always be the current context (not passing the current context name may result in unexpected behavior depending on if the default context exists or not). This change makes collecting revocation information more reliable.

The fix is that revoking an authorization should not remove the authorization from the configuration file. Because of the way default values are computed, this will leave the configuration in an inconsistent state (e.g. the removed authorization may switch over to an authorization named "default" unexpectedly). Leaving the authorization entry in the configuration file and removing the credentials ensures that authorization does not accidentally change.