### PR TITLE
Add application configuration

### DIFF
--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -299,5 +299,5 @@ func (srv *Server) MarshalJSON() ([]byte, error) {
 		Authorization *AuthorizationServer `json:"authorization,omitempty"`
 		API           *APIServer           `json:"api,omitempty"`
 		Application   *ApplicationServer   `json:"application,omitempty"`
-	}{S: (*S)(srv), Authorization: as, API: api, Application: app})
+	}{S: (*S)(srv), Authorization: az, API: api, Application: app})
 }

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -59,6 +59,8 @@ type Server struct {
 	API APIServer `json:"api"`
 	// Authorization contains the authorization server metadata necessary to access this server
 	Authorization AuthorizationServer `json:"authorization"`
+	// Application contains information about the public facing user interface.
+	Application ApplicationServer `json:"application"`
 }
 
 // APIServer is the API server metadata
@@ -67,6 +69,16 @@ type APIServer struct {
 	ExperimentsEndpoint string `json:"experiments_endpoint,omitempty"`
 	// AccountsEndpoint is the URL of the accounts endpoint
 	AccountsEndpoint string `json:"accounts_endpoint,omitempty"`
+}
+
+// ApplicationServer is the user facing application.
+type ApplicationServer struct {
+	// BaseURL is the main entrypoint to the application.
+	BaseURL string `json:"base_url,omitempty"`
+	// AuthSuccessEndpoint is URL to direct the user to after a successful login.
+	AuthSuccessEndpoint string `json:"auth_success_endpoint,omitempty"`
+	// ExperimentsEndpoint is the URL of the experiments UI.
+	ExperimentsEndpoint string `json:"experiments_endpoint,omitempty"`
 }
 
 // NOTE: AuthorizationServer is defined by https://tools.ietf.org/html/rfc8414 do not add non-standard fields!
@@ -278,9 +290,14 @@ func (srv *Server) MarshalJSON() ([]byte, error) {
 	if (APIServer{}) == srv.API {
 		api = nil
 	}
+	app := &srv.Application
+	if (ApplicationServer{}) == srv.Application {
+		app = nil
+	}
 	return json.Marshal(&struct {
 		*S
 		Authorization *AuthorizationServer `json:"authorization,omitempty"`
 		API           *APIServer           `json:"api,omitempty"`
-	}{S: (*S)(srv), Authorization: az, API: api})
+		Application   *ApplicationServer   `json:"application,omitempty"`
+	}{S: (*S)(srv), Authorization: as, API: api, Application: app})
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -66,6 +66,27 @@ func bootstrapClusterName() string {
 	return "default"
 }
 
+// applicationRoots returns the base URLs of the UI and the documentation.
+func applicationRoots(baseURL string) (base string, docs string, err error) {
+	b, err := url.Parse(baseURL)
+	if err != nil {
+		return "", "", err
+	}
+	if b.RawQuery != "" {
+		return "", "", fmt.Errorf("query component is not allowed: %s", baseURL)
+	}
+	if b.Fragment != "" {
+		return "", "", fmt.Errorf("fragment component is not allowed: %s", baseURL)
+	}
+	b.Path = strings.TrimRight(b.Path, "/")
+
+	d := *b
+	d.Path = ""
+	d.Host = "docs." + strings.TrimPrefix(d.Host, "app.")
+
+	return b.String(), d.String(), nil
+}
+
 // defaultString overwrites an empty s1 with the value of s2
 func defaultString(s1 *string, s2 string) {
 	if *s1 == "" {
@@ -79,9 +100,11 @@ func defaultServerRoots(env string, srv *Server) error {
 	case "production":
 		defaultString(&srv.Identifier, "https://api.stormforge.io/v1/")
 		defaultString(&srv.Authorization.Issuer, "https://auth.carbonrelay.io/")
+		defaultString(&srv.Application.BaseURL, "https://app.stormforge.io/")
 	case "development":
 		defaultString(&srv.Identifier, "https://api.stormforge.dev/v1/")
 		defaultString(&srv.Authorization.Issuer, "https://auth.carbonrelay.dev/")
+		defaultString(&srv.Application.BaseURL, "https://app.stormforge.dev/")
 	default:
 		return fmt.Errorf("unknown environment: '%s'", env)
 	}
@@ -98,6 +121,10 @@ func defaultServerEndpoints(srv *Server) error {
 	if err != nil {
 		return err
 	}
+	base, docs, err := applicationRoots(srv.Application.BaseURL)
+	if err != nil {
+		return err
+	}
 
 	// Apply the API defaults
 	defaultString(&srv.API.ExperimentsEndpoint, api+"/experiments/")
@@ -111,6 +138,10 @@ func defaultServerEndpoints(srv *Server) error {
 	// defaultString(&srv.Authorization.RegistrationEndpoint, issuer+"/oauth/register")
 	defaultString(&srv.Authorization.DeviceAuthorizationEndpoint, issuer+"/oauth/device/code")
 	defaultString(&srv.Authorization.JSONWebKeySetURI, discovery.WellKnownURI(issuer, "jwks.json"))
+
+	// Apply the application defaults
+	defaultString(&srv.Application.AuthSuccessEndpoint, docs+"/api/auth_success/")
+	defaultString(&srv.Application.ExperimentsEndpoint, base+"/experiments")
 
 	// Special case for the registration service which is actually part of the accounts API
 	if u, err := url.Parse(srv.API.AccountsEndpoint); err != nil {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -66,25 +66,20 @@ func bootstrapClusterName() string {
 	return "default"
 }
 
-// applicationRoots returns the base URLs of the UI and the documentation.
-func applicationRoots(baseURL string) (base string, docs string, err error) {
+// applicationRoot returns the base URL of the UI.
+func applicationRoot(baseURL string) (base string, err error) {
 	b, err := url.Parse(baseURL)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	if b.RawQuery != "" {
-		return "", "", fmt.Errorf("query component is not allowed: %s", baseURL)
+		return "", fmt.Errorf("query component is not allowed: %s", baseURL)
 	}
 	if b.Fragment != "" {
-		return "", "", fmt.Errorf("fragment component is not allowed: %s", baseURL)
+		return "", fmt.Errorf("fragment component is not allowed: %s", baseURL)
 	}
 	b.Path = strings.TrimRight(b.Path, "/")
-
-	d := *b
-	d.Path = ""
-	d.Host = "docs." + strings.TrimPrefix(d.Host, "app.")
-
-	return b.String(), d.String(), nil
+	return b.String(), nil
 }
 
 // defaultString overwrites an empty s1 with the value of s2
@@ -121,7 +116,7 @@ func defaultServerEndpoints(srv *Server) error {
 	if err != nil {
 		return err
 	}
-	base, docs, err := applicationRoots(srv.Application.BaseURL)
+	base, err := applicationRoot(srv.Application.BaseURL)
 	if err != nil {
 		return err
 	}
@@ -140,7 +135,7 @@ func defaultServerEndpoints(srv *Server) error {
 	defaultString(&srv.Authorization.JSONWebKeySetURI, discovery.WellKnownURI(issuer, "jwks.json"))
 
 	// Apply the application defaults
-	defaultString(&srv.Application.AuthSuccessEndpoint, docs+"/api/auth_success/")
+	defaultString(&srv.Application.AuthSuccessEndpoint, "https://docs.stormforge.io/api/auth_success/")
 	defaultString(&srv.Application.ExperimentsEndpoint, base+"/experiments")
 
 	// Special case for the registration service which is actually part of the accounts API

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -48,6 +48,9 @@ func mergeServer(s1, s2 *Server) {
 	mergeString(&s1.Authorization.RegistrationEndpoint, s2.Authorization.RegistrationEndpoint)
 	mergeString(&s1.Authorization.DeviceAuthorizationEndpoint, s2.Authorization.DeviceAuthorizationEndpoint)
 	mergeString(&s1.Authorization.JSONWebKeySetURI, s2.Authorization.JSONWebKeySetURI)
+	mergeString(&s1.Application.BaseURL, s2.Application.BaseURL)
+	mergeString(&s1.Application.AuthSuccessEndpoint, s2.Application.AuthSuccessEndpoint)
+	mergeString(&s1.Application.ExperimentsEndpoint, s2.Application.ExperimentsEndpoint)
 }
 
 func mergeAuthorization(a1, a2 *Authorization) {


### PR DESCRIPTION
This PR adds configuration for a couple of the UI endpoints, [RE](https://github.com/thestormforge/optimize-controller/pull/234#discussion_r527181349). This will help reduce hard coding in the CLI code and keep the definition of the default URLs consolidated in one place.

Note that this technically requires a fix from #9, the environment was excluded from the configuration merge which means it is not being properly read in for defaults (or migrations).