### PR TITLE
Changes to optimize-go

### DIFF
--- a/pkg/redskyapi/client.go
+++ b/pkg/redskyapi/client.go
@@ -72,10 +72,12 @@ type httpClient struct {
 	endpoints func(string) *url.URL
 }
 
+// URL resolves an endpoint to a fully qualified URL.
 func (c *httpClient) URL(ep string) *url.URL {
 	return c.endpoints(ep)
 }
 
+// Do executes an HTTP request using this client and the supplied context.
 func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
 	if ctx != nil {
 		req = req.WithContext(ctx)

--- a/pkg/redskyapi/client.go
+++ b/pkg/redskyapi/client.go
@@ -22,15 +22,12 @@ import (
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/thestormforge/optimize-go/pkg/config"
 )
 
 // Config exposes the information for configuring a Red Sky Client
 type Config interface {
-	// URL returns the location of the specified endpoint
-	Endpoints() (config.Endpoints, error)
-
+	// Endpoints returns a resolver for the location of the specified endpoint.
+	Endpoints() (func(string) *url.URL, error)
 	// Authorize returns a transport that applies the authorization defined by this configuration. The
 	// supplied context is used for any additional requests necessary to perform authentication. If this
 	// configuration does not define any authorization details, the supplied transport may be returned
@@ -72,11 +69,11 @@ func NewClient(ctx context.Context, cfg Config, transport http.RoundTripper) (Cl
 
 type httpClient struct {
 	client    http.Client
-	endpoints config.Endpoints
+	endpoints func(string) *url.URL
 }
 
 func (c *httpClient) URL(ep string) *url.URL {
-	return c.endpoints.Resolve(ep)
+	return c.endpoints(ep)
 }
 
 func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {

--- a/pkg/redskyapi/experiments/v1alpha1/experiment.go
+++ b/pkg/redskyapi/experiments/v1alpha1/experiment.go
@@ -32,13 +32,13 @@ type ExperimentName interface {
 
 // NewExperimentName returns an experiment name for a given string
 func NewExperimentName(n string) ExperimentName {
-	return experimentName{name: n}
+	return experimentName(n)
 }
 
-type experimentName struct{ name string }
+type experimentName string
 
-func (n experimentName) Name() string   { return n.name }
-func (n experimentName) String() string { return n.name }
+func (n experimentName) Name() string   { return string(n) }
+func (n experimentName) String() string { return string(n) }
 
 type Optimization struct {
 	// The name of the optimization parameter.

--- a/pkg/redskyapi/experiments/v1alpha1/experiment.go
+++ b/pkg/redskyapi/experiments/v1alpha1/experiment.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -150,6 +151,14 @@ func (m *ExperimentMeta) SetLink(rel, link string) {
 	if m.NextTrialURL == "" && strings.ToLower(rel) == "https://carbonrelay.com/rel/nexttrial" {
 		m.NextTrialURL = link
 	}
+}
+func (m *ExperimentMeta) Headers() http.Header {
+	h := metaMarshal("", m.LastModified)
+	metaMarshalLink(h, relationSelf, m.SelfURL)
+	metaMarshalLink(h, relationTrials, m.TrialsURL)
+	metaMarshalLink(h, relationNextTrial, m.NextTrialURL)
+	metaMarshalLink(h, relationLabels, m.LabelsURL)
+	return h
 }
 
 // Experiment combines the search space, outcomes and optimization configuration

--- a/pkg/redskyapi/experiments/v1alpha1/http.go
+++ b/pkg/redskyapi/experiments/v1alpha1/http.go
@@ -493,3 +493,23 @@ func metaUnmarshal(header http.Header, meta Meta) {
 		}
 	}
 }
+
+// metaMarshal is for reconstructing HTTP headers from the unmarshalled metadata.
+func metaMarshal(location string, lastModified time.Time) http.Header {
+	h := make(http.Header)
+	if location != "" {
+		h.Set("Location", location)
+	}
+	if !lastModified.IsZero() {
+		h.Set("Last-Modified", lastModified.UTC().Format(http.TimeFormat))
+	}
+	return h
+}
+
+// metaMarshalLink adds a non-empty link the HTTP headers.
+func metaMarshalLink(h http.Header, rel, link string) {
+	if link == "" {
+		return
+	}
+	h.Add("Link", fmt.Sprintf(`<%s>;rel=%q`, link, rel))
+}

--- a/pkg/redskyapi/experiments/v1alpha1/trial_test.go
+++ b/pkg/redskyapi/experiments/v1alpha1/trial_test.go
@@ -1,0 +1,63 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitTrialName(t *testing.T) {
+	cases := []struct {
+		name           string
+		experimentName string
+		trialNumber    int64
+	}{
+		{
+			name:           "test-001",
+			experimentName: "test",
+			trialNumber:    1,
+		},
+		{
+			name:           "dash-name-001",
+			experimentName: "dash-name",
+			trialNumber:    1,
+		},
+		{
+			name:           "notoctal-010",
+			experimentName: "notoctal",
+			trialNumber:    10,
+		},
+		{
+			name:           "morethenthreedigits-1000",
+			experimentName: "morethenthreedigits",
+			trialNumber:    1000,
+		},
+		{
+			name:           "no-number",
+			experimentName: "no-number",
+			trialNumber:    -1,
+		},
+		{
+			name:           "nodash",
+			experimentName: "nodash",
+			trialNumber:    -1,
+		},
+		{
+			name:           "slash-name/1",
+			experimentName: "slash-name",
+			trialNumber:    1,
+		},
+		{
+			name:           "yolo-2/",
+			experimentName: "yolo-2",
+			trialNumber:    -1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actualExperimentName, actualTrialNumber := SplitTrialName(c.name)
+			assert.Equal(t, c.experimentName, actualExperimentName.Name())
+			assert.Equal(t, c.trialNumber, actualTrialNumber)
+		})
+	}
+}


### PR DESCRIPTION
This PR contains a couple of changes:
1. The experiment name is changed from a `struct{string}` to a plain `string` to make it easier to use internally.
2. The Experiment API client no longer depends on the configuration package: instead of the `Endpoints` type, it just uses a bare `func(string) *url.URL`. This makes it easier to consume if you do not have a full `RedSkyConfig` object.
3. Trial items now have a `Name() string` function (just like experiment items) and there is a helper function to split experiment names and trial numbers when all you have is a trial name.
4. Experiment metadata can be reconstructed into headers, this is necessary to allow for consistently rendering individually fetched experiments.