### PR TITLE
Add CreateExperimentByName

### DIFF
--- a/pkg/api/experiments/v1alpha1/api.go
+++ b/pkg/api/experiments/v1alpha1/api.go
@@ -136,7 +136,8 @@ type API interface {
 	GetAllExperimentsByPage(context.Context, string) (ExperimentList, error)
 	GetExperimentByName(context.Context, ExperimentName) (Experiment, error)
 	GetExperiment(context.Context, string) (Experiment, error)
-	CreateExperiment(context.Context, ExperimentName, Experiment) (Experiment, error)
+	CreateExperimentByName(context.Context, ExperimentName, Experiment) (Experiment, error)
+	CreateExperiment(context.Context, string, Experiment) (Experiment, error)
 	DeleteExperiment(context.Context, string) error
 	GetAllTrials(context.Context, string, *TrialListQuery) (TrialList, error)
 	CreateTrial(context.Context, string, TrialAssignments) (TrialAssignments, error)

--- a/pkg/api/experiments/v1alpha1/http.go
+++ b/pkg/api/experiments/v1alpha1/http.go
@@ -138,8 +138,12 @@ func (h *httpAPI) GetExperiment(ctx context.Context, u string) (Experiment, erro
 	}
 }
 
-func (h *httpAPI) CreateExperiment(ctx context.Context, n ExperimentName, exp Experiment) (Experiment, error) {
+func (h *httpAPI) CreateExperimentByName(ctx context.Context, n ExperimentName, exp Experiment) (Experiment, error) {
 	u := h.client.URL(endpointExperiment + n.Name()).String()
+	return h.CreateExperiment(ctx, u, exp)
+}
+
+func (h *httpAPI) CreateExperiment(ctx context.Context, u string, exp Experiment) (Experiment, error) {
 	e := Experiment{}
 
 	req, err := httpNewJSONRequest(http.MethodPut, u, exp)


### PR DESCRIPTION
This PR makes `CreateExperiment` more consistent with `GetExperiment` in that they should both have a `ByName` variant and a URL variant.