### PR TITLE
Rename environment variables and issuer

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -94,11 +94,11 @@ func defaultServerRoots(env string, srv *Server) error {
 	switch env {
 	case "production":
 		defaultString(&srv.Identifier, "https://api.stormforge.io/v1/")
-		defaultString(&srv.Authorization.Issuer, "https://auth.carbonrelay.io/")
+		defaultString(&srv.Authorization.Issuer, "https://auth.stormforge.io/")
 		defaultString(&srv.Application.BaseURL, "https://app.stormforge.io/")
 	case "development":
 		defaultString(&srv.Identifier, "https://api.stormforge.dev/v1/")
-		defaultString(&srv.Authorization.Issuer, "https://auth.carbonrelay.dev/")
+		defaultString(&srv.Authorization.Issuer, "https://auth.stormforge.dev/")
 		defaultString(&srv.Application.BaseURL, "https://app.stormforge.dev/")
 	default:
 		return fmt.Errorf("unknown environment: '%s'", env)
@@ -107,6 +107,12 @@ func defaultServerRoots(env string, srv *Server) error {
 }
 
 func defaultServerEndpoints(srv *Server) error {
+	// NOTE: The `EnvironmentMapping` function used to create the env for the
+	// controller will set the issuer to scheme and host of the registration
+	// endpoint. This is done so the controller can obtain tokens from an
+	// alternate token endpoint, however it will render most of the remaining
+	// default URLs meaningless as the other endpoints are not supported.
+
 	// Determine the default base URLs
 	api, err := discovery.IssuerURL(srv.Identifier)
 	if err != nil {

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -23,11 +23,11 @@ import (
 
 // envLoader adds environment variable overrides to the configuration
 func envLoader(cfg *RedSkyConfig) error {
-	defaultString(&cfg.Overrides.Environment, os.Getenv("REDSKY_ENV"))
-	defaultString(&cfg.Overrides.ServerIdentifier, os.Getenv("REDSKY_SERVER_IDENTIFIER"))
-	defaultString(&cfg.Overrides.ServerIssuer, os.Getenv("REDSKY_SERVER_ISSUER"))
-	defaultString(&cfg.Overrides.Credential.ClientID, os.Getenv("REDSKY_AUTHORIZATION_CLIENT_ID"))
-	defaultString(&cfg.Overrides.Credential.ClientSecret, os.Getenv("REDSKY_AUTHORIZATION_CLIENT_SECRET"))
+	defaultString(&cfg.Overrides.Environment, os.Getenv("STORMFORGE_ENV"))
+	defaultString(&cfg.Overrides.ServerIdentifier, os.Getenv("STORMFORGE_SERVER_IDENTIFIER"))
+	defaultString(&cfg.Overrides.ServerIssuer, os.Getenv("STORMFORGE_SERVER_ISSUER"))
+	defaultString(&cfg.Overrides.Credential.ClientID, os.Getenv("STORMFORGE_AUTHORIZATION_CLIENT_ID"))
+	defaultString(&cfg.Overrides.Credential.ClientSecret, os.Getenv("STORMFORGE_AUTHORIZATION_CLIENT_SECRET"))
 	return nil
 }
 
@@ -40,8 +40,8 @@ func EnvironmentMapping(r Reader, includeController bool) (map[string][]byte, er
 	if err != nil {
 		return nil, err
 	}
-	env["REDSKY_SERVER_IDENTIFIER"] = []byte(srv.Identifier)
-	env["REDSKY_SERVER_ISSUER"] = []byte(srv.Authorization.Issuer)
+	env["STORMFORGE_SERVER_IDENTIFIER"] = []byte(srv.Identifier)
+	env["STORMFORGE_SERVER_ISSUER"] = []byte(srv.Authorization.Issuer)
 
 	// Record the authorization information
 	az, err := CurrentAuthorization(r)
@@ -49,8 +49,8 @@ func EnvironmentMapping(r Reader, includeController bool) (map[string][]byte, er
 		return nil, err
 	}
 	if az.Credential.ClientCredential != nil {
-		env["REDSKY_AUTHORIZATION_CLIENT_ID"] = []byte(az.Credential.ClientID)
-		env["REDSKY_AUTHORIZATION_CLIENT_SECRET"] = []byte(az.Credential.ClientSecret)
+		env["STORMFORGE_AUTHORIZATION_CLIENT_ID"] = []byte(az.Credential.ClientID)
+		env["STORMFORGE_AUTHORIZATION_CLIENT_SECRET"] = []byte(az.Credential.ClientSecret)
 	}
 
 	// Optionally record environment variables from the controller configuration
@@ -67,7 +67,7 @@ func EnvironmentMapping(r Reader, includeController bool) (map[string][]byte, er
 		// The controller needs it's issuer to match the registration host
 		if u, err := url.Parse(srv.Authorization.RegistrationEndpoint); err == nil {
 			u.Path = "/"
-			env["REDSKY_SERVER_ISSUER"] = []byte(u.String())
+			env["STORMFORGE_SERVER_ISSUER"] = []byte(u.String())
 		}
 	}
 

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package config
 
-import "os"
+import (
+	"net/url"
+	"os"
+)
 
 // envLoader adds environment variable overrides to the configuration
 func envLoader(cfg *RedSkyConfig) error {
@@ -59,6 +62,12 @@ func EnvironmentMapping(r Reader, includeController bool) (map[string][]byte, er
 
 		for i := range ctrl.Env {
 			env[ctrl.Env[i].Name] = []byte(ctrl.Env[i].Value)
+		}
+
+		// The controller needs it's issuer to match the registration host
+		if u, err := url.Parse(srv.Authorization.RegistrationEndpoint); err == nil {
+			u.Path = "/"
+			env["REDSKY_SERVER_ISSUER"] = []byte(u.String())
 		}
 	}
 

--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -38,6 +38,11 @@ func migrationLoader(cfg *RedSkyConfig) error {
 		return err
 	}
 
+	// Migrate the old environment variables
+	if err := migrateRedSkyEnv(cfg); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -135,5 +140,17 @@ func migrateXDGRedSky(cfg *RedSkyConfig) error {
 		return nil
 	})
 
+	return nil
+}
+
+// migrateRedSkyEnv migrates the old environment variables.
+func migrateRedSkyEnv(cfg *RedSkyConfig) error {
+	// This should be consistent with the expected behavior because migrations
+	// run after environment loading and we are only applying defaults to overrides
+	defaultString(&cfg.Overrides.Environment, os.Getenv("REDSKY_ENV"))
+	defaultString(&cfg.Overrides.ServerIdentifier, os.Getenv("REDSKY_SERVER_IDENTIFIER"))
+	defaultString(&cfg.Overrides.ServerIssuer, os.Getenv("REDSKY_SERVER_ISSUER"))
+	defaultString(&cfg.Overrides.Credential.ClientID, os.Getenv("REDSKY_AUTHORIZATION_CLIENT_ID"))
+	defaultString(&cfg.Overrides.Credential.ClientSecret, os.Getenv("REDSKY_AUTHORIZATION_CLIENT_SECRET"))
 	return nil
 }


### PR DESCRIPTION
This change renames both the environment variables and authorization issuer from `REDSKY_...`/`auth.carbonrelay...` to `STORMFORGE_...`/`auth.stormforge...`.

The old environment variables are added to the configuration migration so they will continue to work (this is especially important for controllers where the environment variables are likely already in a secret). However the issuer change is a breaking change that will be dependent on backend changes (in the interim, the issuer can be manually overwritten in the configuration if necessary).

Additionally, the controller based environment mapping of the configuration now returns an issuer based on the registration URL: this accounts for changes to the registration service whereby client credentials tokens should be accessed via a separate service.