### PR TITLE
Change relations from carbonrelay.com to stormforge.io

### DIFF
--- a/pkg/api/experiments/v1alpha1/api.go
+++ b/pkg/api/experiments/v1alpha1/api.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -34,10 +35,38 @@ const (
 	relationNext      = "next"
 	relationPrev      = "prev"
 	relationPrevious  = "previous"
-	relationLabels    = "https://carbonrelay.com/rel/labels"
-	relationTrials    = "https://carbonrelay.com/rel/trials"
-	relationNextTrial = "https://carbonrelay.com/rel/next-trial"
+	relationLabels    = "https://stormforge.io/rel/labels"
+	relationTrials    = "https://stormforge.io/rel/trials"
+	relationNextTrial = "https://stormforge.io/rel/next-trial"
 )
+
+// matchRel checks to see if a relation value matches an expected value. For
+// standard relations, this is simply a case-insensitive equality test; for
+// private relations this function will also test for previously known
+// equivalent relations.
+func matchRel(rel, expected string) bool {
+	rel = strings.ToLower(rel)
+	expected = strings.ToLower(expected)
+	switch expected {
+
+	case relationLabels:
+		return rel == relationLabels ||
+			rel == "https://carbonrelay.com/rel/labels" ||
+			rel == "https://carbonrelay.com/rel/triallabels"
+
+	case relationTrials:
+		return rel == relationTrials ||
+			rel == "https://carbonrelay.com/rel/trials"
+
+	case relationNextTrial:
+		return rel == relationNextTrial ||
+			rel == "https://carbonrelay.com/rel/next-trial" ||
+			rel == "https://carbonrelay.com/rel/nexttrial"
+
+	default:
+		return rel == expected
+	}
+}
 
 // Meta is used to collect resource metadata from the response
 type Meta interface {

--- a/pkg/api/experiments/v1alpha1/experiment.go
+++ b/pkg/api/experiments/v1alpha1/experiment.go
@@ -136,20 +136,15 @@ func (m *ExperimentMeta) SetLastModified(lastModified time.Time) {
 	m.LastModified = lastModified
 }
 func (m *ExperimentMeta) SetLink(rel, link string) {
-	switch strings.ToLower(rel) {
-	case relationSelf:
+	switch {
+	case matchRel(rel, relationSelf):
 		m.SelfURL = link
-	case relationTrials:
+	case matchRel(rel, relationTrials):
 		m.TrialsURL = link
-	case relationNextTrial:
+	case matchRel(rel, relationNextTrial):
 		m.NextTrialURL = link
-	case relationLabels:
+	case matchRel(rel, relationLabels):
 		m.LabelsURL = link
-	}
-
-	// Backwards compatibility with the old next trial relation
-	if m.NextTrialURL == "" && strings.ToLower(rel) == "https://carbonrelay.com/rel/nexttrial" {
-		m.NextTrialURL = link
 	}
 }
 func (m *ExperimentMeta) Headers() http.Header {

--- a/pkg/api/experiments/v1alpha1/trial.go
+++ b/pkg/api/experiments/v1alpha1/trial.go
@@ -34,13 +34,8 @@ type TrialMeta struct {
 func (m *TrialMeta) SetLocation(location string) { m.SelfURL = location }
 func (m *TrialMeta) SetLastModified(time.Time)   {}
 func (m *TrialMeta) SetLink(rel, link string) {
-	switch strings.ToLower(rel) {
-	case relationLabels:
-		m.LabelsURL = link
-	}
-
-	// Backwards compatibility with the old trial labels relation
-	if m.LabelsURL == "" && strings.ToLower(rel) == "https://carbonrelay.com/rel/triallabels" {
+	switch {
+	case matchRel(rel, relationLabels):
 		m.LabelsURL = link
 	}
 }


### PR DESCRIPTION
Getting out in front of this one before the backend makes the switch.