### PR TITLE
Rename RedSkyConfig

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,10 +31,10 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
-// audience is the logical identifier of the Red Sky API
+// audience is the logical identifier of the Optimize API
 const audience = "https://api.carbonrelay.io/v1/"
 
-// Loader is used to initially populate a Red Sky configuration
+// Loader is used to initially populate an Optimize configuration
 type Loader func(cfg *OptimizeConfig) error
 
 // Change is used to apply a configuration change that should be persisted
@@ -43,7 +43,7 @@ type Change func(cfg *Config) error
 // ClientIdentity is a mapping function that returns an OAuth 2.0 `client_id` given an authorization server issuer identifier
 type ClientIdentity func(string) string
 
-// Endpoints exposes the Red Sky API server endpoint locations as a mapping of prefixes to base URLs
+// Endpoints exposes the Optimize API server endpoint locations as a mapping of prefixes to base URLs
 type Endpoints map[string]*url.URL
 
 // OptimizeConfig is the structure used to manage configuration data
@@ -134,7 +134,7 @@ func (rsc *OptimizeConfig) Environment() string {
 	return "production"
 }
 
-// SystemNamespace returns the namespace where the Red Sky controller is/should be installed
+// SystemNamespace returns the namespace where the Optimize Controller is/should be installed
 func (rsc *OptimizeConfig) SystemNamespace() (string, error) {
 	ctrl, err := CurrentController(rsc.Reader())
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ import (
 const audience = "https://api.carbonrelay.io/v1/"
 
 // Loader is used to initially populate a Red Sky configuration
-type Loader func(cfg *RedSkyConfig) error
+type Loader func(cfg *OptimizeConfig) error
 
 // Change is used to apply a configuration change that should be persisted
 type Change func(cfg *Config) error
@@ -46,8 +46,8 @@ type ClientIdentity func(string) string
 // Endpoints exposes the Red Sky API server endpoint locations as a mapping of prefixes to base URLs
 type Endpoints map[string]*url.URL
 
-// RedSkyConfig is the structure used to manage configuration data
-type RedSkyConfig struct {
+// OptimizeConfig is the structure used to manage configuration data
+type OptimizeConfig struct {
 	// Filename is the path to the configuration file; if left blank, it will be populated using XDG base directory conventions on the next Load
 	Filename string
 	// Overrides to the standard configuration
@@ -60,12 +60,12 @@ type RedSkyConfig struct {
 }
 
 // MarshalJSON ensures only the configuration data is marshalled
-func (rsc *RedSkyConfig) MarshalJSON() ([]byte, error) {
+func (rsc *OptimizeConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(rsc.data)
 }
 
 // Load will populate the client configuration
-func (rsc *RedSkyConfig) Load(extra ...Loader) error {
+func (rsc *OptimizeConfig) Load(extra ...Loader) error {
 	var loaders []Loader
 	loaders = append(loaders, fileLoader, envLoader, migrationLoader)
 	loaders = append(loaders, extra...)
@@ -79,7 +79,7 @@ func (rsc *RedSkyConfig) Load(extra ...Loader) error {
 }
 
 // Update will make a change to the configuration data that should be persisted on the next call to Write
-func (rsc *RedSkyConfig) Update(change Change) error {
+func (rsc *OptimizeConfig) Update(change Change) error {
 	if err := change(&rsc.data); err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (rsc *RedSkyConfig) Update(change Change) error {
 }
 
 // Write all unpersisted changes to disk
-func (rsc *RedSkyConfig) Write() error {
+func (rsc *OptimizeConfig) Write() error {
 	if rsc.Filename == "" || len(rsc.unpersisted) == 0 {
 		return nil
 	}
@@ -114,17 +114,17 @@ func (rsc *RedSkyConfig) Write() error {
 
 // Merge combines the supplied data with what is already present in this client configuration; unlike Update, changes
 // will not be persisted on the next write
-func (rsc *RedSkyConfig) Merge(data *Config) {
+func (rsc *OptimizeConfig) Merge(data *Config) {
 	mergeConfig(&rsc.data, data)
 }
 
 // Reader returns a configuration reader for accessing information from the configuration
-func (rsc *RedSkyConfig) Reader() Reader {
+func (rsc *OptimizeConfig) Reader() Reader {
 	return &overrideReader{overrides: &rsc.Overrides, delegate: &defaultReader{cfg: &rsc.data}}
 }
 
 // Environment returns the name of the execution environment
-func (rsc *RedSkyConfig) Environment() string {
+func (rsc *OptimizeConfig) Environment() string {
 	if env := rsc.Overrides.Environment; env != "" {
 		return env
 	}
@@ -135,7 +135,7 @@ func (rsc *RedSkyConfig) Environment() string {
 }
 
 // SystemNamespace returns the namespace where the Red Sky controller is/should be installed
-func (rsc *RedSkyConfig) SystemNamespace() (string, error) {
+func (rsc *OptimizeConfig) SystemNamespace() (string, error) {
 	ctrl, err := CurrentController(rsc.Reader())
 	if err != nil {
 		return "", nil
@@ -144,7 +144,7 @@ func (rsc *RedSkyConfig) SystemNamespace() (string, error) {
 }
 
 // Endpoints returns a resolver that can generate fully qualified endpoint URLs
-func (rsc *RedSkyConfig) Endpoints() (Endpoints, error) {
+func (rsc *OptimizeConfig) Endpoints() (Endpoints, error) {
 	srv, err := CurrentServer(rsc.Reader())
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (ep Endpoints) Resolve(endpoint string) *url.URL {
 }
 
 // Kubectl returns an executable command for running kubectl
-func (rsc *RedSkyConfig) Kubectl(ctx context.Context, arg ...string) (*exec.Cmd, error) {
+func (rsc *OptimizeConfig) Kubectl(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	cstr, err := CurrentCluster(rsc.Reader())
 	if err != nil {
 		return nil, err
@@ -249,7 +249,7 @@ func (ri *RevocationInformation) RemoveAuthorization() Change {
 }
 
 // RevocationInfo returns the information necessary to revoke an authorization entry from the configuration
-func (rsc *RedSkyConfig) RevocationInfo() (*RevocationInformation, error) {
+func (rsc *OptimizeConfig) RevocationInfo() (*RevocationInformation, error) {
 	r := rsc.Reader()
 
 	authorizationName, err := r.AuthorizationName(r.ContextName())
@@ -275,7 +275,7 @@ func (rsc *RedSkyConfig) RevocationInfo() (*RevocationInformation, error) {
 }
 
 // RegisterClient performs dynamic client registration
-func (rsc *RedSkyConfig) RegisterClient(ctx context.Context, client *registration.ClientMetadata) (*registration.ClientInformationResponse, error) {
+func (rsc *OptimizeConfig) RegisterClient(ctx context.Context, client *registration.ClientMetadata) (*registration.ClientInformationResponse, error) {
 	// We can't use the initial token because we don't know if we have a valid token, instead we need to authorize the context client
 	src, err := rsc.tokenSource(ctx)
 	if err != nil {
@@ -297,7 +297,7 @@ func (rsc *RedSkyConfig) RegisterClient(ctx context.Context, client *registratio
 }
 
 // NewAuthorization creates a new authorization code flow with PKCE using the current context
-func (rsc *RedSkyConfig) NewAuthorization() (*authorizationcode.Config, error) {
+func (rsc *OptimizeConfig) NewAuthorization() (*authorizationcode.Config, error) {
 	srv, err := CurrentServer(rsc.Reader())
 	if err != nil {
 		return nil, err
@@ -317,7 +317,7 @@ func (rsc *RedSkyConfig) NewAuthorization() (*authorizationcode.Config, error) {
 }
 
 // NewDeviceAuthorization creates a new device authorization flow using the current context
-func (rsc *RedSkyConfig) NewDeviceAuthorization() (*devicecode.Config, error) {
+func (rsc *OptimizeConfig) NewDeviceAuthorization() (*devicecode.Config, error) {
 	srv, err := CurrentServer(rsc.Reader())
 	if err != nil {
 		return nil, err
@@ -335,7 +335,7 @@ func (rsc *RedSkyConfig) NewDeviceAuthorization() (*devicecode.Config, error) {
 }
 
 // Authorize configures the supplied transport
-func (rsc *RedSkyConfig) Authorize(ctx context.Context, transport http.RoundTripper) (http.RoundTripper, error) {
+func (rsc *OptimizeConfig) Authorize(ctx context.Context, transport http.RoundTripper) (http.RoundTripper, error) {
 	// Get the token source and use it to wrap the transport
 	src, err := rsc.tokenSource(ctx)
 	if err != nil {
@@ -347,8 +347,8 @@ func (rsc *RedSkyConfig) Authorize(ctx context.Context, transport http.RoundTrip
 	return transport, nil
 }
 
-func (rsc *RedSkyConfig) tokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	// TODO We could make RedSkyConfig implement the TokenSource interface, but we need a way to handle the context
+func (rsc *OptimizeConfig) tokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	// TODO We could make OptimizeConfig implement the TokenSource interface, but we need a way to handle the context
 	r := rsc.Reader()
 	srv, err := CurrentServer(r)
 	if err != nil {
@@ -399,7 +399,7 @@ func (rsc *RedSkyConfig) tokenSource(ctx context.Context) (oauth2.TokenSource, e
 	return nil, nil
 }
 
-func (rsc *RedSkyConfig) clientID(srv *Server) string {
+func (rsc *OptimizeConfig) clientID(srv *Server) string {
 	if rsc.ClientIdentity != nil {
 		return rsc.ClientIdentity(srv.Authorization.Issuer)
 	}
@@ -408,7 +408,7 @@ func (rsc *RedSkyConfig) clientID(srv *Server) string {
 
 type updateTokenSource struct {
 	src oauth2.TokenSource
-	cfg *RedSkyConfig
+	cfg *OptimizeConfig
 	az  string
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestEndpoints_Resolve(t *testing.T) {
-	cfg := &RedSkyConfig{}
+	cfg := &OptimizeConfig{}
 	require.NoError(t, defaultLoader(cfg))
 	experimentsEndpoint := &cfg.data.Servers[0].Server.API.ExperimentsEndpoint
 

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -31,7 +31,7 @@ var (
 	DecodeJWT bool
 )
 
-// Config is the top level configuration structure for Red Sky
+// Config is the top level configuration structure for Optimize
 type Config struct {
 	// Servers is a named list of server configurations
 	Servers []NamedServer `json:"servers,omitempty"`
@@ -49,9 +49,9 @@ type Config struct {
 	Environment string `json:"env,omitempty"`
 }
 
-// Server contains information about how to communicate with a Red Sky API Server
+// Server contains information about how to communicate with a StormForge API Server
 type Server struct {
-	// Identifier is a URI used to identify a common set of endpoints making up a Red Sky API Server. The identifier
+	// Identifier is a URI used to identify a common set of endpoints making up a StormForge API Server. The identifier
 	// may be used to resolve ".well-known" locations, used as an authorization audience, or used as a common base URL
 	// when determining default endpoint addresses. The URL must not have any query or fragment components.
 	Identifier string `json:"identifier"`
@@ -143,7 +143,7 @@ type Cluster struct {
 	Controller string `json:"controller,omitempty"`
 }
 
-// Controller contains additional controller configuration when working with Red Sky on a specific cluster
+// Controller contains additional controller configuration when working with Optimize on a specific cluster
 type Controller struct {
 	// DeploymentName is the name of the controller deployment object
 	DeploymentName string `json:"deploymentName,omitempty"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -25,9 +25,9 @@ import (
 	"github.com/thestormforge/optimize-go/pkg/oauth2/discovery"
 )
 
-// The default loader must NEVER make changes via RedSkyConfig.Update or RedSkyConfig.unpersisted
+// The default loader must NEVER make changes via OptimizeConfig.Update or OptimizeConfig.unpersisted
 
-func defaultLoader(cfg *RedSkyConfig) error {
+func defaultLoader(cfg *OptimizeConfig) error {
 	// NOTE: Any errors reported here are effectively fatal errors for a program that needs configuration since they will
 	// not be able to load the configuration. Errors should be limited to unusable configurations.
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -215,8 +215,8 @@ func (d *defaults) applyControllerDefaults() error {
 	for i := range d.cfg.Controllers {
 		ctrl := &d.cfg.Controllers[i].Controller
 
-		defaultString(&ctrl.DeploymentName, "redsky-controller-manager")
-		defaultString(&ctrl.Namespace, "redsky-system")
+		defaultString(&ctrl.DeploymentName, "optimize-controller-manager")
+		defaultString(&ctrl.Namespace, "stormforge-system")
 	}
 	return nil
 }

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -22,7 +22,7 @@ import (
 )
 
 // envLoader adds environment variable overrides to the configuration
-func envLoader(cfg *RedSkyConfig) error {
+func envLoader(cfg *OptimizeConfig) error {
 	defaultString(&cfg.Overrides.Environment, os.Getenv("STORMFORGE_ENV"))
 	defaultString(&cfg.Overrides.ServerIdentifier, os.Getenv("STORMFORGE_SERVER_IDENTIFIER"))
 	defaultString(&cfg.Overrides.ServerIssuer, os.Getenv("STORMFORGE_SERVER_ISSUER"))

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -37,7 +37,7 @@ const (
 )
 
 // fileLoader loads a configuration from the currently configured filename
-func fileLoader(cfg *RedSkyConfig) error {
+func fileLoader(cfg *OptimizeConfig) error {
 	f := &file{filename: cfg.Filename}
 
 	// If we are using a configuration file, the filename _must_ be set

--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -27,7 +27,7 @@ import (
 )
 
 // migrationLoader will take the meaningful bits from a legacy config file and delete that file once the changes are persisted
-func migrationLoader(cfg *RedSkyConfig) error {
+func migrationLoader(cfg *OptimizeConfig) error {
 	// Migrate the really old `~/.redsky` file
 	if err := migrateDotRedSky(cfg); err != nil {
 		return err
@@ -47,7 +47,7 @@ func migrationLoader(cfg *RedSkyConfig) error {
 }
 
 // migrateDotRedSky migrates the really old '~/.redsky' file into the supplied configuration.
-func migrateDotRedSky(cfg *RedSkyConfig) error {
+func migrateDotRedSky(cfg *OptimizeConfig) error {
 	filename := filepath.Join(os.Getenv("HOME"), ".redsky")
 
 	f, err := os.Open(filename)
@@ -89,7 +89,7 @@ func migrateDotRedSky(cfg *RedSkyConfig) error {
 }
 
 // migrateXDGRedSky migrates the old '~/.config/redsky/config' file into the supplied configuration.
-func migrateXDGRedSky(cfg *RedSkyConfig) error {
+func migrateXDGRedSky(cfg *OptimizeConfig) error {
 	filename, _ := configFilename("redsky/config")
 
 	f, err := os.Open(filename)
@@ -144,7 +144,7 @@ func migrateXDGRedSky(cfg *RedSkyConfig) error {
 }
 
 // migrateRedSkyEnv migrates the old environment variables.
-func migrateRedSkyEnv(cfg *RedSkyConfig) error {
+func migrateRedSkyEnv(cfg *OptimizeConfig) error {
 	// This should be consistent with the expected behavior because migrations
 	// run after environment loading and we are only applying defaults to overrides
 	defaultString(&cfg.Overrides.Environment, os.Getenv("REDSKY_ENV"))

--- a/pkg/config/overrides.go
+++ b/pkg/config/overrides.go
@@ -20,11 +20,11 @@ package config
 type Overrides struct {
 	// Environment overrides the execution environment name
 	Environment string
-	// Context overrides the current Red Sky context name (_not_ the KubeConfig context)
+	// Context overrides the current Optimize context name (_not_ the KubeConfig context)
 	Context string
 	// SystemNamespace overrides the current controller namespace (_not_ the Kube namespace)
 	SystemNamespace string
-	// ServerIdentifier overrides the current server's identifier and Red Sky endpoints. Using this override, it is not possible to specify individual endpoint locations.
+	// ServerIdentifier overrides the current server's identifier and StormForge endpoints. Using this override, it is not possible to specify individual endpoint locations.
 	ServerIdentifier string
 	// ServerIssuer overrides the current server's authorization server issuer. Using this override, it is not possible to specify individual endpoint locations.
 	ServerIssuer string

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -132,7 +132,7 @@ func Minify(r Reader) (*Config, error) {
 	return cfg, nil
 }
 
-// TODO Instead of defaultReader, just have RedSkyConfig implement Reader?
+// TODO Instead of defaultReader, just have OptimizeConfig implement Reader?
 
 var _ Reader = &defaultReader{}
 

--- a/pkg/config/update.go
+++ b/pkg/config/update.go
@@ -119,7 +119,7 @@ func SetProperty(name, value string) Change {
 	if name == "env" {
 		return SetExecutionEnvironment(value)
 	}
-	// TODO This is a giant hack. Consider not even supporting `redskyctl config set` generically
+	// TODO This is a giant hack. Consider not even supporting `config set` generically
 	return func(cfg *Config) error {
 		path := strings.Split(name, ".")
 		switch path[0] {


### PR DESCRIPTION
This PR removes the last of the "Red Sky" references from the StormForge Optimize common library (except for those required for migration).