### PR TITLE
Fix constraint marshaling

### DIFF
--- a/pkg/api/experiments/v1alpha1/experiment.go
+++ b/pkg/api/experiments/v1alpha1/experiment.go
@@ -91,9 +91,9 @@ type Constraint struct {
 	// Optional name for constraint.
 	Name string `json:"name,omitempty"`
 
-	ConstraintType  ConstraintType `json:"constraintType"`
-	SumConstraint   `json:",inline"`
-	OrderConstraint `json:",inline"`
+	ConstraintType   ConstraintType `json:"constraintType"`
+	*SumConstraint   `json:",omitempty"`
+	*OrderConstraint `json:",omitempty"`
 }
 
 type ParameterType string


### PR DESCRIPTION
This PR changes the type of the embedded constraint fields to be pointers to the respective typed configurations. The current output effectively includes the fields from both configurations (sum and order); and since some of those fields are required, they are always present in the output (e.g. if `constraintType` is `sum` and the `SumConstraint` fields are populated, the marshaled JSON also includes empty strings for the required `lowerParameter` and `upperParameter` on the `OrderConstraint`).

Also note that the `inline` option for the JSON tags isn't actually a thing, so replacing that with `omitempty` (which for the pointer fields is necessary to prevent the bug) is actually a bonus fix here.

This change will require downstream code changes because the type of an exported field has been changed.