### PR TITLE
Common metadata

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// ErrorType is an identifying token for errors.
+type ErrorType string
+
+const (
+	ErrUnauthorized ErrorType = "unauthorized"
+	ErrUnexpected   ErrorType = "unexpected"
+)
+
+// Error represents the API specific error messages and may be used in response to HTTP status codes
+type Error struct {
+	Type       ErrorType     `json:"-"`
+	Message    string        `json:"error"`
+	RetryAfter time.Duration `json:"-"`
+	Location   string        `json:"-"`
+}
+
+// Error returns the message associated with this API error.
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// NewUnexpectedError returns an error in situations where the API returned an
+// undocumented status for the requested resource.
+func NewUnexpectedError(resp *http.Response, body []byte) *Error {
+	t := ErrUnexpected
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusPaymentRequired:
+		t = ErrUnauthorized
+	}
+	return NewError(t, resp, body)
+}
+
+// NewError returns a new error with an API specific error condition, it also captures the details of the response
+func NewError(t ErrorType, resp *http.Response, body []byte) *Error {
+	err := &Error{Type: t}
+
+	// Unmarshal the response body into the error to get the server supplied error message
+	// TODO We should be comparing compatible media types here (e.g. charset)
+	if resp.Header.Get("Content-Type") == "application/json" {
+		_ = json.Unmarshal(body, err)
+	}
+
+	// Capture the URL of the request
+	if resp.Request != nil && resp.Request.URL != nil {
+		err.Location = resp.Request.URL.String()
+	}
+
+	// Capture the Retry-After header for "service unavailable"
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		if ra, raerr := strconv.Atoi(resp.Header.Get("Retry-After")); raerr == nil {
+			if ra < 1 {
+				ra = 5
+			} else if ra > 120 {
+				ra = 120
+			}
+			err.RetryAfter = time.Duration(ra) * time.Second
+		}
+	}
+
+	// Make sure we have a message
+	if err.Message == "" {
+		switch resp.StatusCode {
+		case http.StatusNotFound:
+			err.Message = fmt.Sprintf("not found: %s", err.Location)
+		case http.StatusUnauthorized:
+			err.Message = "unauthorized"
+		case http.StatusPaymentRequired:
+			err.Message = "account is not activated"
+		default:
+			switch err.Type {
+			case ErrUnexpected:
+				err.Message = fmt.Sprintf("unexpected server response (%s)", http.StatusText(resp.StatusCode))
+			default:
+				err.Message = strings.ReplaceAll(string(err.Type), "-", " ")
+			}
+		}
+	}
+
+	return err
+}
+
+// IsUnauthorized checks to see if the error is an "unauthorized" error.
+func IsUnauthorized(err error) bool {
+	// OAuth errors (e.g. fetching tokens) will have a full HTTP response
+	var oauthErr *oauth2.RetrieveError
+	if errors.As(err, &oauthErr) && oauthErr.Response.StatusCode == http.StatusUnauthorized {
+		return true
+	}
+
+	// Our API errors have an identifiable type code
+	var apiErr *Error
+	if errors.As(err, &apiErr) && apiErr.Type == ErrUnauthorized {
+		return true
+	}
+
+	// Handle a specific gateway generated error message
+	if err != nil && err.Error() == "no Bearer token" {
+		return true
+	}
+
+	return false
+}

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+func TestNewError(t *testing.T) {
+	cases := []struct {
+		desc      string
+		errorType ErrorType
+		response  http.Response
+		body      []byte
+		expected  Error
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc:      "api message",
+			errorType: ErrorType("test-error"),
+			response: http.Response{
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+			},
+			body: []byte(`{"error":"test message"}`),
+			expected: Error{
+				Type:    "test-error",
+				Message: "test message",
+			},
+		},
+		{
+			desc:      "not found",
+			errorType: ErrorType("test-error"),
+			response: http.Response{
+				StatusCode: http.StatusNotFound,
+				Request: &http.Request{
+					URL: &url.URL{
+						Scheme: "https",
+						Host:   "invalid.example.com",
+						Path:   "/testing",
+					},
+				},
+			},
+			expected: Error{
+				Type:    "test-error",
+				Message: "not found: https://invalid.example.com/testing",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			assert.Error(t, &c.expected, NewError(c.errorType, &c.response, c.body))
+		})
+	}
+}
+
+func TestIsUnauthorized(t *testing.T) {
+	cases := []struct {
+		desc     string
+		err      error
+		expected bool
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc: "format error",
+			err:  fmt.Errorf("test"),
+		},
+		{
+			desc:     "hard coded error text",
+			err:      fmt.Errorf("no Bearer token"),
+			expected: true,
+		},
+		{
+			desc:     "api error",
+			err:      &Error{Type: ErrUnauthorized},
+			expected: true,
+		},
+		{
+			desc:     "wrapped api error",
+			err:      fmt.Errorf("test: %w", &Error{Type: ErrUnauthorized}),
+			expected: true,
+		},
+		{
+			desc: "oauth2 error",
+			err: &url.Error{ // http.Client.Do wraps errors in *url.Error
+				Err: &oauth2.RetrieveError{
+					Response: &http.Response{
+						StatusCode: http.StatusUnauthorized,
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			assert.Equal(t, c.expected, IsUnauthorized(c.err))
+		})
+	}
+}

--- a/pkg/api/experiments/v1alpha1/experiment_test.go
+++ b/pkg/api/experiments/v1alpha1/experiment_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+func TestExperimentList_UnmarshalJSON(t *testing.T) {
+	data := []byte(`
+{
+  "experiments": [
+    {
+      "_metadata": {
+        "Link": "</test1>; rel=self"
+      },
+      "displayName": "Test1"
+    },
+    {
+      "_metadata": {
+        "Link": [
+          "</test2>; rel=self",
+          "</test2?offset=5>; rel=next"
+        ]
+      },
+      "displayName": "Test2"
+    }
+  ]
+}
+`)
+
+	l := ExperimentList{}
+	err := json.Unmarshal(data, &l)
+	if assert.NoError(t, err) {
+		assert.Len(t, l.Experiments, 2)
+
+		assert.Equal(t, "/test1", l.Experiments[0].Link(api.RelationSelf))
+		assert.Equal(t, "Test1", l.Experiments[0].DisplayName)
+
+		assert.Equal(t, "/test2", l.Experiments[1].Link(api.RelationSelf))
+		assert.Equal(t, "/test2?offset=5", l.Experiments[1].Link(api.RelationNext))
+		assert.Equal(t, "Test2", l.Experiments[1].DisplayName)
+	}
+}

--- a/pkg/api/experiments/v1alpha1/http.go
+++ b/pkg/api/experiments/v1alpha1/http.go
@@ -23,14 +23,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/thestormforge/optimize-go/pkg/api"
 )
 
-// NewAPI returns a new API implementation for the specified client
+const endpointExperiments = "/v1/experiments/"
+
+// NewAPI returns a new API implementation for the specified client.
 func NewAPI(c api.Client) API {
 	return &httpAPI{client: c}
 }
@@ -39,13 +39,15 @@ type httpAPI struct {
 	client api.Client
 }
 
-func (h *httpAPI) Options(ctx context.Context) (ServerMeta, error) {
-	u := h.client.URL(endpointExperiment).String()
-	sm := ServerMeta{}
+var _ API = &httpAPI{}
+
+func (h *httpAPI) Options(ctx context.Context) (Server, error) {
+	u := h.client.URL(endpointExperiments).String()
+	s := Server{}
 
 	req, err := http.NewRequest(http.MethodOptions, u, nil)
 	if err != nil {
-		return sm, err
+		return s, err
 	}
 
 	// We actually want to do OPTIONS for the whole server, now that the host:port has been captured, overwrite the RequestURL
@@ -54,23 +56,23 @@ func (h *httpAPI) Options(ctx context.Context) (ServerMeta, error) {
 
 	resp, body, err := h.client.Do(ctx, req)
 	if err != nil {
-		return sm, err
+		return s, err
 	}
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusNoContent,
 		// TODO Current behavior is to return 404 or 405 instead of 204 (or 200?)
 		http.StatusNotFound, http.StatusMethodNotAllowed:
-		sm.Unmarshal(resp.Header)
-		return sm, nil
+		s.Metadata = api.Metadata(resp.Header)
+		return s, nil
 	default:
-		return sm, newError(ErrUnexpected, resp, body)
+		return s, api.NewUnexpectedError(resp, body)
 	}
 }
 
-func (h *httpAPI) GetAllExperiments(ctx context.Context, q *ExperimentListQuery) (ExperimentList, error) {
-	u := h.client.URL(endpointExperiment)
-	u.RawQuery = q.Encode()
+func (h *httpAPI) GetAllExperiments(ctx context.Context, q ExperimentListQuery) (ExperimentList, error) {
+	u := h.client.URL(endpointExperiments)
+	u.RawQuery = url.Values(q.IndexQuery).Encode()
 
 	return h.GetAllExperimentsByPage(ctx, u.String())
 }
@@ -90,23 +92,20 @@ func (h *httpAPI) GetAllExperimentsByPage(ctx context.Context, u string) (Experi
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		metaUnmarshal(resp.Header, &lst.ExperimentListMeta)
+		lst.Metadata = api.Metadata(resp.Header)
 		err = json.Unmarshal(body, &lst)
-		for i := range lst.Experiments {
-			metaUnmarshal(http.Header(lst.Experiments[i].Metadata), &lst.Experiments[i].Experiment.ExperimentMeta)
-		}
 		return lst, err
 	default:
-		return lst, newError(ErrUnexpected, resp, body)
+		return lst, api.NewUnexpectedError(resp, body)
 	}
 }
 
 func (h *httpAPI) GetExperimentByName(ctx context.Context, n ExperimentName) (Experiment, error) {
-	u := h.client.URL(endpointExperiment + n.Name()).String()
+	u := h.client.URL(endpointExperiments + n.Name()).String()
 	exp, err := h.GetExperiment(ctx, u)
 
 	// Improve the "not found" error message using the name
-	if eerr, ok := err.(*Error); ok && eerr.Type == ErrExperimentNotFound {
+	if eerr, ok := err.(*api.Error); ok && eerr.Type == ErrExperimentNotFound {
 		eerr.Message = fmt.Sprintf(`experiment "%s" not found`, n.Name())
 	}
 
@@ -128,18 +127,18 @@ func (h *httpAPI) GetExperiment(ctx context.Context, u string) (Experiment, erro
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		metaUnmarshal(resp.Header, &e.ExperimentMeta)
+		e.Metadata = api.Metadata(resp.Header)
 		err = json.Unmarshal(body, &e)
 		return e, err
 	case http.StatusNotFound:
-		return e, newError(ErrExperimentNotFound, resp, body)
+		return e, api.NewError(ErrExperimentNotFound, resp, body)
 	default:
-		return e, newError(ErrUnexpected, resp, body)
+		return e, api.NewUnexpectedError(resp, body)
 	}
 }
 
 func (h *httpAPI) CreateExperimentByName(ctx context.Context, n ExperimentName, exp Experiment) (Experiment, error) {
-	u := h.client.URL(endpointExperiment + n.Name()).String()
+	u := h.client.URL(endpointExperiments + n.Name()).String()
 	return h.CreateExperiment(ctx, u, exp)
 }
 
@@ -158,17 +157,17 @@ func (h *httpAPI) CreateExperiment(ctx context.Context, u string, exp Experiment
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated:
-		metaUnmarshal(resp.Header, &e.ExperimentMeta)
+		e.Metadata = api.Metadata(resp.Header)
 		err = json.Unmarshal(body, &e)
 		return e, err
 	case http.StatusBadRequest:
-		return e, newError(ErrExperimentNameInvalid, resp, body)
+		return e, api.NewError(ErrExperimentNameInvalid, resp, body)
 	case http.StatusConflict:
-		return e, newError(ErrExperimentNameConflict, resp, body)
+		return e, api.NewError(ErrExperimentNameConflict, resp, body)
 	case http.StatusUnprocessableEntity:
-		return e, newError(ErrExperimentInvalid, resp, body)
+		return e, api.NewError(ErrExperimentInvalid, resp, body)
 	default:
-		return e, newError(ErrUnexpected, resp, body)
+		return e, api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -187,16 +186,16 @@ func (h *httpAPI) DeleteExperiment(ctx context.Context, u string) error {
 	case http.StatusNoContent:
 		return nil
 	case http.StatusNotFound:
-		return newError(ErrExperimentNotFound, resp, body)
+		return api.NewError(ErrExperimentNotFound, resp, body)
 	default:
-		return newError(ErrUnexpected, resp, body)
+		return api.NewUnexpectedError(resp, body)
 	}
 }
 
-func (h *httpAPI) GetAllTrials(ctx context.Context, u string, q *TrialListQuery) (TrialList, error) {
+func (h *httpAPI) GetAllTrials(ctx context.Context, u string, q TrialListQuery) (TrialList, error) {
 	lst := TrialList{}
 
-	rawQuery := q.Encode()
+	rawQuery := url.Values(q.IndexQuery).Encode()
 	if rawQuery != "" {
 		if uu, err := url.Parse(u); err == nil {
 			// TODO Should we be merging the query in this case?
@@ -218,12 +217,9 @@ func (h *httpAPI) GetAllTrials(ctx context.Context, u string, q *TrialListQuery)
 	switch resp.StatusCode {
 	case http.StatusOK:
 		err = json.Unmarshal(body, &lst)
-		for i := range lst.Trials {
-			metaUnmarshal(http.Header(lst.Trials[i].Metadata), &lst.Trials[i].TrialAssignments.TrialMeta)
-		}
 		return lst, err
 	default:
-		return lst, newError(ErrUnexpected, resp, body)
+		return lst, api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -242,15 +238,15 @@ func (h *httpAPI) CreateTrial(ctx context.Context, u string, asm TrialAssignment
 
 	switch resp.StatusCode {
 	case http.StatusCreated, http.StatusAccepted:
-		metaUnmarshal(resp.Header, &ta.TrialMeta)
+		ta.Metadata = api.Metadata(resp.Header)
 		err = json.Unmarshal(body, &ta)
 		return ta, nil // TODO Stop ignoring this when the server starts sending a response body
 	case http.StatusConflict:
-		return ta, newError(ErrExperimentStopped, resp, body)
+		return ta, api.NewError(ErrExperimentStopped, resp, body)
 	case http.StatusUnprocessableEntity:
-		return ta, newError(ErrTrialInvalid, resp, body)
+		return ta, api.NewError(ErrTrialInvalid, resp, body)
 	default:
-		return ta, newError(ErrUnexpected, resp, body)
+		return ta, api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -269,15 +265,15 @@ func (h *httpAPI) NextTrial(ctx context.Context, u string) (TrialAssignments, er
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		metaUnmarshal(resp.Header, &asm.TrialMeta)
+		asm.Metadata = api.Metadata(resp.Header)
 		err = json.Unmarshal(body, &asm)
 		return asm, err
 	case http.StatusGone:
-		return asm, newError(ErrExperimentStopped, resp, body)
+		return asm, api.NewError(ErrExperimentStopped, resp, body)
 	case http.StatusServiceUnavailable:
-		return asm, newError(ErrTrialUnavailable, resp, body)
+		return asm, api.NewError(ErrTrialUnavailable, resp, body)
 	default:
-		return asm, newError(ErrUnexpected, resp, body)
+		return asm, api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -308,13 +304,13 @@ func (h *httpAPI) ReportTrial(ctx context.Context, u string, vls TrialValues) er
 	case http.StatusCreated:
 		return nil
 	case http.StatusNotFound:
-		return newError(ErrTrialNotFound, resp, body)
+		return api.NewError(ErrTrialNotFound, resp, body)
 	case http.StatusConflict:
-		return newError(ErrTrialAlreadyReported, resp, body)
+		return api.NewError(ErrTrialAlreadyReported, resp, body)
 	case http.StatusUnprocessableEntity:
-		return newError(ErrTrialInvalid, resp, body)
+		return api.NewError(ErrTrialInvalid, resp, body)
 	default:
-		return newError(ErrUnexpected, resp, body)
+		return api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -333,9 +329,9 @@ func (h *httpAPI) AbandonRunningTrial(ctx context.Context, u string) error {
 	case http.StatusNoContent:
 		return nil
 	case http.StatusNotFound:
-		return newError(ErrTrialNotFound, resp, body)
+		return api.NewError(ErrTrialNotFound, resp, body)
 	default:
-		return newError(ErrUnexpected, resp, body)
+		return api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -354,11 +350,11 @@ func (h *httpAPI) LabelExperiment(ctx context.Context, u string, lbl ExperimentL
 	case http.StatusCreated:
 		return nil
 	case http.StatusNotFound:
-		return newError(ErrTrialNotFound, resp, body)
+		return api.NewError(ErrTrialNotFound, resp, body)
 	case http.StatusUnprocessableEntity:
-		return newError(ErrTrialInvalid, resp, body)
+		return api.NewError(ErrTrialInvalid, resp, body)
 	default:
-		return newError(ErrUnexpected, resp, body)
+		return api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -377,11 +373,11 @@ func (h *httpAPI) LabelTrial(ctx context.Context, u string, lbl TrialLabels) err
 	case http.StatusCreated:
 		return nil
 	case http.StatusNotFound:
-		return newError(ErrTrialNotFound, resp, body)
+		return api.NewError(ErrTrialNotFound, resp, body)
 	case http.StatusUnprocessableEntity:
-		return newError(ErrTrialInvalid, resp, body)
+		return api.NewError(ErrTrialInvalid, resp, body)
 	default:
-		return newError(ErrUnexpected, resp, body)
+		return api.NewUnexpectedError(resp, body)
 	}
 }
 
@@ -399,121 +395,4 @@ func httpNewJSONRequest(method, u string, body interface{}) (*http.Request, erro
 	req.Header.Set("Content-Type", "application/json")
 
 	return req, err
-}
-
-// newError returns a new error with an API specific error condition, it also captures the details of the response
-func newError(t ErrorType, resp *http.Response, body []byte) error {
-	err := &Error{Type: t}
-
-	// Unmarshal the response body into the error to get the server supplied error message
-	// TODO We should be comparing compatible media types here (e.g. charset)
-	if resp.Header.Get("Content-Type") == "application/json" {
-		_ = json.Unmarshal(body, err)
-	}
-
-	// Capture the URL of the request
-	if resp.Request != nil && resp.Request.URL != nil {
-		err.Location = resp.Request.URL.String()
-	}
-
-	// Capture the Retry-After header for "service unavailable"
-	if resp.StatusCode == http.StatusServiceUnavailable {
-		if ra, raerr := strconv.Atoi(resp.Header.Get("Retry-After")); raerr == nil {
-			if ra < 1 {
-				ra = 5
-			} else if ra > 120 {
-				ra = 120
-			}
-			err.RetryAfter = time.Duration(ra) * time.Second
-		}
-	}
-
-	// Try to report a more specific error if the error was undocumented (e.g. came from a proxy)
-	if err.Type == ErrUnexpected {
-		switch resp.StatusCode {
-		case http.StatusUnauthorized:
-			err.Type = ErrUnauthorized
-			if err.Message == "" {
-				err.Message = "unauthorized"
-			}
-		case http.StatusPaymentRequired:
-			err.Type = ErrUnauthorized
-			if err.Message == "" {
-				err.Message = "account is not activated"
-			}
-		default:
-			if err.Message == "" {
-				err.Message = fmt.Sprintf("unexpected server response (%s)", http.StatusText(resp.StatusCode))
-			}
-		}
-	}
-
-	// Make sure we have a message
-	if err.Message == "" {
-		switch resp.StatusCode {
-		case http.StatusNotFound:
-			err.Message = fmt.Sprintf("not found: %s", err.Location)
-		default:
-			err.Message = strings.ReplaceAll(string(err.Type), "-", " ")
-		}
-	}
-
-	return err
-}
-
-// Extract metadata from the response headers, failures are silently ignored, always call before extracting entity body
-func metaUnmarshal(header http.Header, meta Meta) {
-	if location := header.Get("Location"); location != "" {
-		meta.SetLocation(location)
-	}
-
-	if text := header.Get("Last-Modified"); text != "" {
-		if lastModified, err := http.ParseTime(text); err == nil {
-			meta.SetLastModified(lastModified)
-		}
-	}
-
-	for _, rh := range header[http.CanonicalHeaderKey("Link")] {
-		for _, h := range strings.Split(rh, ",") {
-			var link, rel string
-			for _, l := range strings.Split(h, ";") {
-				l = strings.Trim(l, " ")
-				if l == "" {
-					continue
-				}
-
-				if l[0] == '<' && l[len(l)-1] == '>' {
-					link = strings.Trim(l, "<>")
-					continue
-				}
-
-				p := strings.SplitN(l, "=", 2)
-				if len(p) == 2 && strings.ToLower(p[0]) == "rel" {
-					rel = strings.Trim(p[1], "\"")
-					continue
-				}
-			}
-			meta.SetLink(rel, link)
-		}
-	}
-}
-
-// metaMarshal is for reconstructing HTTP headers from the unmarshalled metadata.
-func metaMarshal(location string, lastModified time.Time) http.Header {
-	h := make(http.Header)
-	if location != "" {
-		h.Set("Location", location)
-	}
-	if !lastModified.IsZero() {
-		h.Set("Last-Modified", lastModified.UTC().Format(http.TimeFormat))
-	}
-	return h
-}
-
-// metaMarshalLink adds a non-empty link the HTTP headers.
-func metaMarshalLink(h http.Header, rel, link string) {
-	if link == "" {
-		return
-	}
-	h.Add("Link", fmt.Sprintf(`<%s>;rel=%q`, link, rel))
 }

--- a/pkg/api/experiments/v1alpha1/http.go
+++ b/pkg/api/experiments/v1alpha1/http.go
@@ -28,7 +28,7 @@ import (
 	"github.com/thestormforge/optimize-go/pkg/api"
 )
 
-const endpointExperiments = "/v1/experiments/"
+const endpointExperiments = "/experiments/"
 
 // NewAPI returns a new API implementation for the specified client.
 func NewAPI(c api.Client) API {

--- a/pkg/api/experiments/v1alpha1/trial_test.go
+++ b/pkg/api/experiments/v1alpha1/trial_test.go
@@ -1,10 +1,61 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/thestormforge/optimize-go/pkg/api"
 )
+
+func TestTrialList_UnmarshalJSON(t *testing.T) {
+	data := []byte(`
+{
+  "trials": [
+    {
+      "_metadata": {
+        "Link": [
+          "</labelTest1>; rel=https://stormforge.io/rel/labels"
+        ]
+      },
+      "number": 1,
+      "failureReason": "test",
+      "labels": {
+        "best": "true"
+      }
+    },
+    {
+      "_metadata": {
+        "Link": [
+          "</labelTest2>; rel=https://stormforge.io/rel/labels"
+        ]
+      },
+      "number": 2,
+      "failureReason": "test",
+      "labels": {
+        "manually_created": "true"
+      }
+    }
+  ]
+}
+`)
+
+	l := TrialList{}
+	err := json.Unmarshal(data, &l)
+	if assert.NoError(t, err) {
+		assert.Len(t, l.Trials, 2)
+
+		assert.Equal(t, "/labelTest1", l.Trials[0].Link(api.RelationLabels))
+		assert.Equal(t, int64(1), l.Trials[0].Number)
+		assert.Equal(t, "test", l.Trials[0].FailureReason)
+		assert.Equal(t, "true", l.Trials[0].Labels["best"])
+
+		assert.Equal(t, "/labelTest2", l.Trials[1].Link(api.RelationLabels))
+		assert.Equal(t, int64(2), l.Trials[1].Number)
+		assert.Equal(t, "test", l.Trials[1].FailureReason)
+		assert.Equal(t, "true", l.Trials[1].Labels["manually_created"])
+	}
+}
 
 func TestSplitTrialName(t *testing.T) {
 	cases := []struct {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	ParamOffset        = "offset"
+	ParamLimit         = "limit"
+	ParamLabelSelector = "labelSelector"
+)
+
+// IndexQuery represents the query parameter of an index resource.
+type IndexQuery map[string][]string
+
+// SetOffset sets the number of items to skip from the beginning of the index.
+func (q IndexQuery) SetOffset(offset int) {
+	if offset != 0 {
+		url.Values(q).Set(ParamOffset, strconv.Itoa(offset))
+	} else {
+		url.Values(q).Del(ParamOffset)
+	}
+}
+
+// SetLimit sets the maximum number of items to include with the index.
+func (q IndexQuery) SetLimit(limit int) {
+	if limit != 0 {
+		url.Values(q).Set(ParamLimit, strconv.Itoa(limit))
+	} else {
+		url.Values(q).Del(ParamLimit)
+	}
+}
+
+// SetLabelSelector is a helper to set label selectors used to filter the index.
+func (q IndexQuery) SetLabelSelector(kv map[string]string) {
+	ls := make([]string, 0, len(kv))
+	for k, v := range kv {
+		ls = append(ls, fmt.Sprintf("%s=%s", k, v))
+	}
+	if len(ls) > 0 {
+		sort.Strings(ls)
+		url.Values(q).Add(ParamLabelSelector, strings.Join(ls, ","))
+	}
+}

--- a/pkg/api/index_test.go
+++ b/pkg/api/index_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexQuery_SetLimit(t *testing.T) {
+	q := IndexQuery{}
+
+	q.SetLimit(11)
+	q.SetLimit(97)
+	assert.Equal(t, []string{"97"}, q[ParamLimit])
+
+	q.SetLimit(0)
+	assert.NotContains(t, q, ParamLimit)
+}
+
+func TestIndexQuery_SetLabelSelector(t *testing.T) {
+	q := IndexQuery{}
+
+	q.SetLabelSelector(map[string]string{
+		"application": "my-app",
+		"scenario":    "cyber-monday",
+	})
+	assert.Equal(t, []string{"application=my-app,scenario=cyber-monday"}, q[ParamLabelSelector])
+
+	q.SetLabelSelector(map[string]string{
+		"best": "true",
+	})
+	assert.Equal(t, []string{"application=my-app,scenario=cyber-monday", "best=true"}, q[ParamLabelSelector])
+}

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const (
+	RelationSelf      = "self"
+	RelationNext      = "next"
+	RelationPrev      = "prev"
+	RelationAlternate = "alternate"
+	RelationLabels    = "https://stormforge.io/rel/labels"
+	RelationTrials    = "https://stormforge.io/rel/trials"
+	RelationNextTrial = "https://stormforge.io/rel/next-trial"
+)
+
+// Metadata is used to hold single or multi-value metadata from list responses.
+type Metadata map[string][]string
+
+func (m Metadata) Title() string {
+	return http.Header(m).Get("Title")
+}
+func (m Metadata) SetTitle(value string) {
+	if value != "" {
+		http.Header(m).Set("Title", value)
+	}
+}
+
+func (m Metadata) Location() string {
+	return http.Header(m).Get("Location")
+}
+func (m Metadata) SetLocation(value string) {
+	if value != "" {
+		http.Header(m).Set("Location", value)
+	}
+}
+
+func (m Metadata) LastModified() time.Time {
+	value, _ := http.ParseTime(http.Header(m).Get("Last-Modified"))
+	return value
+}
+func (m Metadata) SetLastModified(t time.Time) {
+	if !t.IsZero() {
+		http.Header(m).Set("Last-Modified", t.UTC().Format(http.TimeFormat))
+	}
+}
+
+func (m Metadata) Link(rel string) string {
+	for _, rh := range http.Header(m).Values("Link") {
+		for _, h := range strings.Split(rh, ",") {
+			r, l := splitLink(h)
+			if strings.EqualFold(rel, r) {
+				return l
+			}
+		}
+	}
+	return ""
+}
+func (m Metadata) SetLink(rel, link string) {
+	if link == "" {
+		return
+	}
+
+	values := http.Header(m).Values("Link")
+	http.Header(m).Del("Link")
+	var added bool
+	for _, rh := range values {
+		for _, h := range strings.Split(rh, ",") {
+			r, l := splitLink(h)
+			if strings.EqualFold(rel, r) {
+				l = link
+				added = true
+			}
+			http.Header(m).Add("Link", fmt.Sprintf(`<%s>;rel=%q`, l, r))
+		}
+	}
+
+	if !added {
+		http.Header(m).Add("Link", fmt.Sprintf(`<%s>;rel=%q`, link, rel))
+	}
+}
+
+func splitLink(value string) (rel, link string) {
+	for _, l := range strings.Split(value, ";") {
+		l = strings.Trim(l, " ")
+		if l == "" {
+			continue
+		}
+
+		if l[0] == '<' && l[len(l)-1] == '>' {
+			link = strings.Trim(l, "<>")
+			continue
+		}
+
+		p := strings.SplitN(l, "=", 2)
+		if len(p) == 2 && strings.ToLower(p[0]) == "rel" {
+			rel = strings.Trim(p[1], "\"")
+			continue
+		}
+	}
+
+	switch strings.ToLower(rel) {
+	case "previous":
+		rel = RelationPrev
+
+	case "https://carbonrelay.com/rel/labels",
+		"https://carbonrelay.com/rel/triallabels":
+		rel = RelationLabels
+
+	case "https://carbonrelay.com/rel/trials":
+		rel = RelationTrials
+
+	case "https://carbonrelay.com/rel/next-trial",
+		"https://carbonrelay.com/rel/nexttrial":
+		rel = RelationNextTrial
+	}
+
+	return
+}
+
+// UnmarshalJSON extracts the supplied JSON, preserving the "_metadata" field if
+// necessary. This should only be necessary on items in index (list) representations
+// as top-level "_metadata" fields should normally be populated from HTTP headers.
+func UnmarshalJSON(b []byte, v interface{}) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	rv := reflect.Indirect(reflect.ValueOf(v))
+	for i := 0; i < rv.NumField(); i++ {
+		f := rv.Field(i)
+		ft := rv.Type().Field(i)
+		k := strings.SplitN(ft.Tag.Get("json"), ",", 2)[0]
+		if len(raw[k]) > 0 {
+			if err := json.Unmarshal(raw[k], f.Addr().Interface()); err != nil {
+				return err
+			}
+		} else if k == "-" && f.Type() == reflect.TypeOf(Metadata{}) {
+			if err := unmarshalMetadata(f, raw["_metadata"]); err != nil {
+				return err
+			}
+		} else if ft.Anonymous {
+			if err := UnmarshalJSON(b, f.Addr().Interface()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func unmarshalMetadata(f reflect.Value, raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	md := make(map[string]interface{})
+	if err := json.Unmarshal(raw, &md); err != nil {
+		return err
+	}
+
+	m := Metadata{}
+	for k, v := range md {
+		switch t := v.(type) {
+		case string:
+			m[k] = append(m[k], t)
+		case []interface{}:
+			for i := range t {
+				m[k] = append(m[k], fmt.Sprintf("%s", t[i]))
+			}
+		}
+	}
+
+	f.Set(reflect.ValueOf(m))
+	return nil
+}

--- a/pkg/api/metadata_test.go
+++ b/pkg/api/metadata_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadata_Headers(t *testing.T) {
+	md := Metadata{}
+
+	// Overwrite and ignore blanks
+	md.SetTitle("Overwritten")
+	md.SetTitle("Testing")
+	assert.Equal(t, "Testing", md.Title())
+	md.SetTitle("")
+	assert.Equal(t, "Testing", md.Title())
+
+	// Last-Modified ignores parse failures
+	md["Last-Modified"] = []string{"fail"}
+	assert.Equal(t, time.Time{}, md.LastModified())
+
+	// We expect normalized header names
+	http.Header(md).Set("location", "https://invalid.example.com/testing")
+	assert.NotContains(t, md, "location")
+	assert.Equal(t, "https://invalid.example.com/testing", md.Location())
+}
+
+func TestMetadata_Links(t *testing.T) {
+	md := Metadata{}
+
+	// Simple set/get
+	md.SetLink(RelationNext, "https://invalid.example.com/list?offset=10")
+	assert.Equal(t, "https://invalid.example.com/list?offset=10", md.Link(RelationNext))
+	assert.Equal(t, []string{`<https://invalid.example.com/list?offset=10>;rel="next"`}, md["Link"])
+
+	// Expand existing comma-delimited values on write
+	md["Link"] = []string{`</foo>;rel=abc,</bar>;rel=xyz`}
+	md.SetLink("abc", "/test")
+	assert.Equal(t, []string{`</test>;rel="abc"`, `</bar>;rel="xyz"`}, md["Link"])
+
+	// We do not normalize on set...
+	delete(md, "Link")
+	md.SetLink("previous", "/list?offset=0")
+	assert.Equal(t, []string{`</list?offset=0>;rel="previous"`}, md["Link"])
+
+	// ...but we do on get
+	assert.Equal(t, "", md.Link("previous"))
+	assert.Equal(t, "/list?offset=0", md.Link("prev"))
+}


### PR DESCRIPTION
This PR moves the generic handlers for errors, metadata (HTTP headers), and index queries up to the `api` package so they can be reused later for API(s) to be named later.

I eliminated the `Meta` interface and just implemented it using the existing `Metadata` type, I think it made the `Metadata` type itself a bit more complicated but now there is only one generic implementation instead every object needing to implement its own supporting metadata type.

Also, there was a fluke with a shadowed `labels` map on the trials (both the list item and the embedded assignments had labels); that has been resolved as well.