### PR TITLE
fix: Use correct json field name for parameter name

### DIFF
--- a/pkg/api/experiments/v1alpha1/experiment.go
+++ b/pkg/api/experiments/v1alpha1/experiment.go
@@ -66,7 +66,7 @@ const (
 
 type SumConstraintParameter struct {
 	// Name of parameter to be used in constraint.
-	Name string `json:"name"`
+	Name string `json:"parameterName"`
 	// Weight for parameter in constraint.
 	Weight float64 `json:"weight"`
 }


### PR DESCRIPTION
This fixes an issue where we emit the parameter name for a sum constraint as
`name` instead of `parameterName`.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>