### PR TITLE
Fix set calls on nil index query

### DIFF
--- a/pkg/api/experiments/v1alpha1/trial.go
+++ b/pkg/api/experiments/v1alpha1/trial.go
@@ -85,6 +85,9 @@ func (q *TrialListQuery) SetStatus(status ...TrialStatus) {
 		str = append(str, string(s))
 	}
 	if len(str) > 0 {
+		if q.IndexQuery == nil {
+			q.IndexQuery = api.IndexQuery{}
+		}
 		url.Values(q.IndexQuery).Set("status", strings.Join(str, ","))
 	}
 }
@@ -93,6 +96,9 @@ func (q *TrialListQuery) AddStatus(status TrialStatus) {
 	value := string(status)
 	if v := url.Values(q.IndexQuery).Get("status"); v != "" {
 		value = v + "," + value
+	}
+	if q.IndexQuery == nil {
+		q.IndexQuery = api.IndexQuery{}
 	}
 	url.Values(q.IndexQuery).Set("status", value)
 }

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -34,31 +34,40 @@ const (
 type IndexQuery map[string][]string
 
 // SetOffset sets the number of items to skip from the beginning of the index.
-func (q IndexQuery) SetOffset(offset int) {
+func (q *IndexQuery) SetOffset(offset int) {
+	if *q == nil {
+		*q = IndexQuery{}
+	}
 	if offset != 0 {
-		url.Values(q).Set(ParamOffset, strconv.Itoa(offset))
+		url.Values(*q).Set(ParamOffset, strconv.Itoa(offset))
 	} else {
-		url.Values(q).Del(ParamOffset)
+		url.Values(*q).Del(ParamOffset)
 	}
 }
 
 // SetLimit sets the maximum number of items to include with the index.
-func (q IndexQuery) SetLimit(limit int) {
+func (q *IndexQuery) SetLimit(limit int) {
+	if *q == nil {
+		*q = IndexQuery{}
+	}
 	if limit != 0 {
-		url.Values(q).Set(ParamLimit, strconv.Itoa(limit))
+		url.Values(*q).Set(ParamLimit, strconv.Itoa(limit))
 	} else {
-		url.Values(q).Del(ParamLimit)
+		url.Values(*q).Del(ParamLimit)
 	}
 }
 
 // SetLabelSelector is a helper to set label selectors used to filter the index.
-func (q IndexQuery) SetLabelSelector(kv map[string]string) {
+func (q *IndexQuery) SetLabelSelector(kv map[string]string) {
 	ls := make([]string, 0, len(kv))
 	for k, v := range kv {
 		ls = append(ls, fmt.Sprintf("%s=%s", k, v))
 	}
 	if len(ls) > 0 {
 		sort.Strings(ls)
-		url.Values(q).Add(ParamLabelSelector, strings.Join(ls, ","))
+		if *q == nil {
+			*q = IndexQuery{}
+		}
+		url.Values(*q).Add(ParamLabelSelector, strings.Join(ls, ","))
 	}
 }

--- a/pkg/api/index_test.go
+++ b/pkg/api/index_test.go
@@ -47,3 +47,13 @@ func TestIndexQuery_SetLabelSelector(t *testing.T) {
 	})
 	assert.Equal(t, []string{"application=my-app,scenario=cyber-monday", "best=true"}, q[ParamLabelSelector])
 }
+
+func TestIndexQuery_nil(t *testing.T) {
+	// Ensure the setter on a nil value allocates a map, otherwise embedding the
+	// IndexQuery will have unexpected results
+	q := IndexQuery(nil)
+	assert.Nil(t, q)
+	q.SetLimit(97)
+	assert.NotNil(t, q)
+	assert.Equal(t, []string{"97"}, q[ParamLimit])
+}


### PR DESCRIPTION
This is what you get for type aliasing a `map`. A `map` can be `nil`, in fact, the zero value for a `map` is `nil`. As a result, when an `IndexQuery` is embedded in another type (e.g. `type ExperimentListQuery struct { api.IndexQuery }`) the zero value of the embedded field is...`nil`.

This PR changes the receiver for the `Set...` methods to be an `*IndexQuery`, that way we can test for `nil` and, if necessary, allocate storage (which confusingly can look like a struct allocation but is really allocating an empty map ala `x := map[k]v{}` style). The test for `nil` needs to be dereferenced because we are dealing with _pointers_ to a `map`: e.g. `*IndexQuery` is a `*map[string][]string` so if `q` is a `*IndexQuery` then `*q` is just a `map` (which itself can be `nil`). Note that `(*(**IndexQuery)(nil)).SetLimit(10)` _will_ still panic because we wouldn't be able to allocate anything back to the caller.