### PR TITLE
Initial Application API Go client

### DIFF
--- a/pkg/api/applications/v2/activity.go
+++ b/pkg/api/applications/v2/activity.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+type ActivityFeed struct {
+	HomePageURL string         `json:"home_page_url,omitempty"`
+	FeedURL     string         `json:"feed_url,omitempty"`
+	NextURL     string         `json:"next_url,omitempty"`
+	Hubs        []ActivityHub  `json:"hubs,omitempty"`
+	Items       []ActivityItem `json:"items"`
+}
+
+type ActivityHub struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+type ActivityItem struct {
+	ID            string             `json:"id"`
+	URL           string             `json:"url,omitempty"`
+	ExternalURL   string             `json:"external_url,omitempty"`
+	Title         string             `json:"title,omitempty"`
+	DatePublished time.Time          `json:"date_published,omitempty"`
+	DateModified  time.Time          `json:"date_modified,omitempty"`
+	Tags          []string           `json:"tags,omitempty"`
+	StormForge    *ActivityExtension `json:"_stormforge,omitempty"`
+}
+
+type ActivityExtension struct {
+	ActivityFailure
+}
+
+type ActivityFeedQuery struct {
+	Query map[string][]string
+}
+
+func (q *ActivityFeedQuery) SetType(t string) {
+	url.Values(q.Query).Set("type", t)
+}
+
+type Activity struct {
+	api.Metadata `json:"-"`
+	Run          *RunActivity  `json:"run,omitempty"`
+	Scan         *ScanActivity `json:"scan,omitempty"`
+}
+
+type RunActivity struct {
+	ActivityFailure
+}
+
+type ScanActivity struct {
+	ActivityFailure
+}
+
+type ActivityFailure struct {
+	FailureReason  string `json:"failure_reason,omitempty"`
+	FailureMessage string `json:"failure_message,omitempty"`
+}

--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+const (
+	ErrApplicationInvalid  api.ErrorType = "application-invalid"
+	ErrApplicationNotFound api.ErrorType = "application-not-found"
+	ErrScenarioInvalid     api.ErrorType = "scenario-invalid"
+	ErrScenarioNotFound    api.ErrorType = "scenario-not-found"
+	ErrScanInvalid         api.ErrorType = "scan-invalid"
+	ErrActivityInvalid     api.ErrorType = "activity-invalid"
+	ErrActivityRateLimited api.ErrorType = "activity-rate-limited"
+)
+
+// ApplicationName represents a name token used to identify an application.
+type ApplicationName interface {
+	// Name returns the string representation of the application name.
+	Name() string
+}
+
+// Subscriber describes a strategy for subscribing to feed notifications.
+type Subscriber interface {
+	// Subscribe initiates a subscription that continues for the lifetime of the context.
+	Subscribe(ctx context.Context, ch chan<- ActivityItem)
+}
+
+type API interface {
+	// ListApplications gets a list of existing applications for an authorized request.
+	ListApplications(ctx context.Context, q ApplicationListQuery) (ApplicationList, error)
+	// ListApplicationsByPage returns single page of applications identified by the supplied URL.
+	ListApplicationsByPage(ctx context.Context, u string) (ApplicationList, error)
+	// CreateApplication creates a new application.
+	CreateApplication(ctx context.Context, app Application) (api.Metadata, error)
+	// GetApplication retrieves an application.
+	GetApplication(ctx context.Context, u string) (Application, error)
+	// GetApplicationByName retrieves an application.
+	GetApplicationByName(ctx context.Context, n ApplicationName) (Application, error)
+	// UpsertApplication updates or creates an application.
+	UpsertApplication(ctx context.Context, u string, app Application) (api.Metadata, error)
+	// UpsertApplicationByName updates or creates an application.
+	UpsertApplicationByName(ctx context.Context, n ApplicationName, app Application) (api.Metadata, error)
+	// DeleteApplication deletes an application.
+	DeleteApplication(ctx context.Context, u string) error
+
+	// ListScenarios lists configured scenarios for an application.
+	ListScenarios(ctx context.Context, u string, q ScenarioListQuery) (ScenarioList, error)
+	// CreateScenario creates a scenario.
+	CreateScenario(ctx context.Context, u string, scn Scenario) (api.Metadata, error)
+	// GetScenario retrieves a scenario.
+	GetScenario(ctx context.Context, u string) (Scenario, error)
+	// UpsertScenario updates or creates a scenario with the URL scenario name.
+	UpsertScenario(ctx context.Context, u string, scn Scenario) (Scenario, error)
+	// DeleteScenario deletes a scenario.
+	DeleteScenario(ctx context.Context, u string) error
+	// PatchScenario updates attributes on a scenario.
+	PatchScenario(ctx context.Context, u string, scn Scenario) error
+
+	// GetScan gets application scenario scan.
+	GetScan(ctx context.Context, u string) (Scan, error)
+	// UpdateScan records or updates cluster scan results.
+	UpdateScan(ctx context.Context, u string, s Scan) error
+	// PatchScan updates partial cluster scan results.
+	PatchScan(ctx context.Context, u string, s Scan) error
+
+	// ListActivity gets activity feed for an application.
+	ListActivity(ctx context.Context, u string, q ActivityFeedQuery) (ActivityFeed, error)
+	// CreateActivity creates application activity.
+	CreateActivity(ctx context.Context, u string, a Activity) error
+	// DeleteActivity resolves application activity.
+	DeleteActivity(ctx context.Context, u string) error
+	// GetApplicationActivity retrieves an application activity item by ID.
+	GetApplicationActivity(ctx context.Context, u string) (Activity, error)
+	// UpdateApplicationActivity updates application activity.
+	UpdateApplicationActivity(ctx context.Context, u string, a Activity) error
+
+	// SubscribeActivity returns a subscriber for the activity feed.
+	SubscribeActivity(ctx context.Context, q ActivityFeedQuery) (Subscriber, error)
+}

--- a/pkg/api/applications/v2/application.go
+++ b/pkg/api/applications/v2/application.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+// NewApplicationName returns an application name for a given string.
+func NewApplicationName(n string) ApplicationName {
+	return applicationName(n)
+}
+
+type applicationName string
+
+func (n applicationName) Name() string   { return string(n) }
+func (n applicationName) String() string { return string(n) }
+
+type Application struct {
+	api.Metadata `json:"-"`
+	Name_        string        `json:"name"`
+	DisplayName  string        `json:"title,omitempty"`
+	Resources    []interface{} `json:"resources,omitempty"`
+}
+
+func (a *Application) Name() string {
+	return a.Name_
+}
+
+type ApplicationListQuery struct{ api.IndexQuery }
+
+type ApplicationItem struct {
+	Application
+	// The number of scenarios associated with this application.
+	ScenarioCount int `json:"scenarioCount,omitempty"`
+}
+
+func (l *ApplicationItem) UnmarshalJSON(b []byte) error { return api.UnmarshalJSON(b, l) }
+
+type ApplicationList struct {
+	// The application list metadata.
+	api.Metadata `json:"-"`
+	// The total number of items in the collection.
+	TotalCount int `json:"totalCount,omitempty"`
+	// The list of applications.
+	Applications []ApplicationItem `json:"applications,omitempty"`
+}

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -1,0 +1,556 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+const endpointApplications = "/v2/applications/"
+
+func NewAPI(c api.Client) API {
+	return &httpAPI{client: c}
+}
+
+type httpAPI struct {
+	client api.Client
+}
+
+var _ API = &httpAPI{}
+
+func (h *httpAPI) ListApplications(ctx context.Context, q ApplicationListQuery) (ApplicationList, error) {
+	u := h.client.URL(endpointApplications)
+	u.RawQuery = url.Values(q.IndexQuery).Encode()
+
+	return h.ListApplicationsByPage(ctx, u.String())
+}
+
+func (h *httpAPI) ListApplicationsByPage(ctx context.Context, u string) (ApplicationList, error) {
+	result := ApplicationList{}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result.Metadata = api.Metadata(resp.Header)
+		err = json.Unmarshal(body, &result)
+		return result, err
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) CreateApplication(ctx context.Context, app Application) (api.Metadata, error) {
+	u := h.client.URL(endpointApplications).String()
+
+	req, err := httpNewJSONRequest(http.MethodPost, u, app)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		return api.Metadata(resp.Header), nil
+	case http.StatusBadRequest:
+		return nil, api.NewError(ErrApplicationInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return nil, api.NewError(ErrApplicationInvalid, resp, body)
+	default:
+		return nil, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) GetApplication(ctx context.Context, u string) (Application, error) {
+	result := Application{}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result.Metadata = api.Metadata(resp.Header)
+		err = json.Unmarshal(body, &result)
+		return result, err
+	case http.StatusNotFound:
+		return result, api.NewError(ErrApplicationNotFound, resp, body)
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) GetApplicationByName(ctx context.Context, n ApplicationName) (Application, error) {
+	u := h.client.URL(endpointApplications + n.Name()).String()
+	result, err := h.GetApplication(ctx, u)
+
+	// Improve the "not found" error message using the name
+	if eerr, ok := err.(*api.Error); ok && eerr.Type == ErrApplicationNotFound {
+		eerr.Message = fmt.Sprintf(`application "%s" not found`, n.Name())
+	}
+
+	return result, err
+}
+
+func (h *httpAPI) UpsertApplication(ctx context.Context, u string, app Application) (api.Metadata, error) {
+	req, err := httpNewJSONRequest(http.MethodPut, u, app)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusCreated, http.StatusAccepted:
+		return api.Metadata(resp.Header), nil
+	case http.StatusBadRequest:
+		return nil, api.NewError(ErrApplicationInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return nil, api.NewError(ErrApplicationInvalid, resp, body)
+	default:
+		return nil, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) UpsertApplicationByName(ctx context.Context, n ApplicationName, app Application) (api.Metadata, error) {
+	u := h.client.URL(endpointApplications + n.Name()).String()
+	return h.UpsertApplication(ctx, u, app)
+}
+
+func (h *httpAPI) DeleteApplication(ctx context.Context, u string) error {
+	req, err := http.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return api.NewError(ErrApplicationNotFound, resp, body)
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) ListScenarios(ctx context.Context, u string, q ScenarioListQuery) (ScenarioList, error) {
+	u = applyQuery(u, url.Values(q.IndexQuery))
+	result := ScenarioList{}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		err = json.Unmarshal(body, &result)
+		return result, err
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) CreateScenario(ctx context.Context, u string, scn Scenario) (api.Metadata, error) {
+	req, err := httpNewJSONRequest(http.MethodPost, u, scn)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		return api.Metadata(resp.Header), nil
+	case http.StatusBadRequest:
+		return nil, api.NewError(ErrScenarioInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return nil, api.NewError(ErrScenarioInvalid, resp, body)
+	default:
+		return nil, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) GetScenario(ctx context.Context, u string) (Scenario, error) {
+	result := Scenario{}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result.Metadata = api.Metadata(resp.Header)
+		err = json.Unmarshal(body, &result)
+		return result, err
+	case http.StatusNotFound:
+		return result, api.NewError(ErrScenarioNotFound, resp, body)
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) UpsertScenario(ctx context.Context, u string, scn Scenario) (Scenario, error) {
+	result := Scenario{}
+
+	req, err := httpNewJSONRequest(http.MethodPut, u, scn)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		result.Metadata = api.Metadata(resp.Header)
+		err = json.Unmarshal(body, &result)
+		return result, err
+	case http.StatusBadRequest:
+		return result, api.NewError(ErrScenarioInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return result, api.NewError(ErrScenarioInvalid, resp, body)
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) DeleteScenario(ctx context.Context, u string) error {
+	req, err := http.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) PatchScenario(ctx context.Context, u string, scn Scenario) error {
+	req, err := httpNewJSONRequest(http.MethodPatch, u, scn)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusBadRequest:
+		return api.NewError(ErrScenarioInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return api.NewError(ErrScenarioInvalid, resp, body)
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) GetScan(ctx context.Context, u string) (Scan, error) {
+	result := Scan{}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		err = json.Unmarshal(body, &result)
+		return result, err
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) UpdateScan(ctx context.Context, u string, s Scan) error {
+	req, err := httpNewJSONRequest(http.MethodPut, u, s)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusCreated, http.StatusAccepted:
+		return nil
+	case http.StatusBadRequest:
+		return api.NewError(ErrScanInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return api.NewError(ErrScanInvalid, resp, body)
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) PatchScan(ctx context.Context, u string, s Scan) error {
+	req, err := httpNewJSONRequest(http.MethodPatch, u, s)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusBadRequest:
+		return api.NewError(ErrScanInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return api.NewError(ErrScanInvalid, resp, body)
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) ListActivity(ctx context.Context, u string, q ActivityFeedQuery) (ActivityFeed, error) {
+	u = applyQuery(u, q.Query)
+	result := ActivityFeed{}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		err = json.Unmarshal(body, &result)
+		return result, err
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) CreateActivity(ctx context.Context, u string, a Activity) error {
+	req, err := httpNewJSONRequest(http.MethodPost, u, a)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusBadRequest:
+		return api.NewError(ErrActivityInvalid, resp, body)
+	case http.StatusUnprocessableEntity:
+		return api.NewError(ErrActivityInvalid, resp, body)
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) DeleteActivity(ctx context.Context, u string) error {
+	req, err := http.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) GetApplicationActivity(ctx context.Context, u string) (Activity, error) {
+	result := Activity{}
+
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return result, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result.Metadata = api.Metadata(resp.Header)
+		err = json.Unmarshal(body, &result)
+		return result, err
+	case http.StatusTooManyRequests:
+		return result, api.NewError(ErrActivityRateLimited, resp, body)
+	default:
+		return result, api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) UpdateApplicationActivity(ctx context.Context, u string, a Activity) error {
+	req, err := httpNewJSONRequest(http.MethodPut, u, a)
+	if err != nil {
+		return err
+	}
+
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusCreated, http.StatusAccepted:
+		return nil
+	default:
+		return api.NewUnexpectedError(resp, body)
+	}
+}
+
+func (h *httpAPI) SubscribeActivity(ctx context.Context, q ActivityFeedQuery) (Subscriber, error) {
+	// TODO This should be a HEAD request
+	lst, err := h.ListApplications(ctx, ApplicationListQuery{})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO Also filter on `type=application/feed+json`
+	u := lst.Link(api.RelationAlternate)
+	if u == "" {
+		return nil, fmt.Errorf("missing activity feed URL")
+	}
+
+	feed, err := h.ListActivity(ctx, u, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSubscriber(h, feed), nil
+}
+
+// httpNewJSONRequest returns a new HTTP request with a JSON payload
+func httpNewJSONRequest(method, u string, body interface{}) (*http.Request, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, u, bytes.NewBuffer(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, err
+}
+
+// applyQuery adds the query values to the supplied URL.
+func applyQuery(u string, q url.Values) string {
+	if len(q) == 0 {
+		return u
+	}
+
+	uu, err := url.Parse(u)
+	if err != nil {
+		return u + "?" + q.Encode()
+	}
+
+	qq := uu.Query()
+	for k, v := range q {
+		// TODO Do we need to be smart about merging with "," strings instead?
+		qq[k] = append(qq[k], v...)
+	}
+
+	uu.RawQuery = qq.Encode()
+	return uu.String()
+}

--- a/pkg/api/applications/v2/scenario.go
+++ b/pkg/api/applications/v2/scenario.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"encoding/json"
+
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+type Scenario struct {
+	api.Metadata  `json:"-"`
+	Name          string        `json:"name"`
+	DisplayName   string        `json:"title,omitempty"`
+	Configuration []interface{} `json:"configuration,omitempty"`
+	Objective     []interface{} `json:"objective,omitempty"`
+}
+
+type ScenarioListQuery struct{ api.IndexQuery }
+
+type ScenarioItem struct {
+	Scenario
+}
+
+func (l *ScenarioItem) UnmarshalJSON(b []byte) error { return api.UnmarshalJSON(b, l) }
+
+type ScenarioList struct {
+	// The scenario list metadata.
+	api.Metadata `json:"-"`
+	// The total number of items in the collection.
+	TotalCount int `json:"totalCount,omitempty"`
+	// The list of scenarios.
+	Scenarios []ScenarioItem `json:"scenarios,omitempty"`
+}
+
+type ScanParameterBounds struct {
+	// The minimum value for a numeric parameter.
+	Min json.Number `json:"min,omitempty"`
+	// The maximum value for a numeric parameter.
+	Max json.Number `json:"max,omitempty"`
+}
+
+type ScanParameter struct {
+	// The name of the parameter.
+	Name string `json:"name"`
+	// The type of the parameter.
+	Type string `json:"type"`
+	// The optional baseline value of the parameter, either numeric or categorical.
+	Baseline *api.NumberOrString `json:"baseline,omitempty"`
+	// The domain of the parameter.
+	Bounds *ScanParameterBounds `json:"bounds,omitempty"`
+	// The list of allowed categorical values for the parameter.
+	Values []string `json:"values,omitempty"`
+}
+
+type ScanMetricBounds struct {
+	// The minimum value for a metric.
+	Min float64 `json:"min,omitempty"`
+	// The maximum value for a metric.
+	Max float64 `json:"max,omitempty"`
+}
+
+type ScanMetric struct {
+	// The name of the metric.
+	Name string `json:"name"`
+	// The flag indicating this metric should be minimized.
+	Minimize bool `json:"minimize,omitempty"`
+	// The flag indicating this metric is optimized (nil defaults to true).
+	Optimize *bool `json:"optimize,omitempty"`
+	// The domain of the metric
+	Bounds *ScanMetricBounds `json:"bounds,omitempty"`
+}
+
+type Scan struct {
+	// The list of parameters for this scan.
+	Parameters []ScanParameter `json:"parameters,omitempty"`
+	// The list of metrics for this scan.
+	Metrics []ScanMetric `json:"metrics,omitempty"`
+}

--- a/pkg/api/applications/v2/subscribe.go
+++ b/pkg/api/applications/v2/subscribe.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sort"
+	"time"
+
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+// NewSubscriber returns a subscriber for the supplied feed.
+func NewSubscriber(api API, feed ActivityFeed) Subscriber {
+	// Check the feed hubs for any subscription strategies we support
+	for _, hub := range feed.Hubs {
+		switch hub.Type {
+		case "poll":
+			// Allow the server to force polling
+			return &PollingSubscriber{API: api, FeedURL: hub.URL}
+		}
+	}
+
+	// By default, return a simple polling subscriber on the feed URL
+	return &PollingSubscriber{API: api, FeedURL: feed.FeedURL}
+}
+
+// PollingSubscriber is a primitive strategy that simply polls for changes.
+type PollingSubscriber struct {
+	// The API instance used to fetch the feed.
+	API API
+	// The URL to poll.
+	FeedURL string
+	// Time between polling requests. Defaults to 30 seconds.
+	PollInterval time.Duration
+	// Adjust the poll duration by a random amount. Defaults to 1.0, effectively
+	// a random amount up to the full poll interval.
+	JitterFactor float64
+
+	// The server may periodically request a longer delay.
+	rateLimit time.Duration
+}
+
+// PollTimer returns a new timer for the next polling operation.
+func (s *PollingSubscriber) PollTimer() *time.Timer {
+	// Default to 30 seconds
+	interval := s.PollInterval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+
+	// Default to a factor of 1.0 (i.e. a random value from 0 to a full extra interval)
+	jitter := rand.Float64() * float64(interval)
+	if s.JitterFactor > 0 {
+		jitter *= s.JitterFactor
+	}
+
+	// Include the server requested rate limit just for this timer
+	// TODO If `s.rateLimit > interval` should we update `s.PollInterval` to prevent excessive 429s?
+	interval += s.rateLimit
+	s.rateLimit = 0
+
+	return time.NewTimer(interval + time.Duration(jitter))
+}
+
+// Subscribe starts fetching the activity feed
+func (s *PollingSubscriber) Subscribe(ctx context.Context, ch chan<- ActivityItem) {
+	go func() {
+		// Close the channel when we are done sending things
+		defer close(ch)
+
+		lastID := ""
+		for {
+			// Wait for the timer
+			t := s.PollTimer()
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			}
+
+			// Fetch the feed and send new items to the channel
+			f, err := s.API.ListActivity(ctx, s.FeedURL, ActivityFeedQuery{})
+			if err != nil {
+				var apiErr *api.Error
+				if errors.As(err, &apiErr) {
+					switch apiErr.Type {
+					case ErrActivityRateLimited:
+						s.rateLimit = apiErr.RetryAfter
+						continue
+					}
+				}
+
+				// TODO What other errors should just be ignored or reported?
+				return
+			}
+
+			lastID = s.notify(f.Items, lastID, ch)
+		}
+	}()
+}
+
+// notify sends all of the items from the supplied feed to the channel.
+// IMPORTANT: this function assumes item identifiers can be compared lexicographically.
+func (s *PollingSubscriber) notify(items []ActivityItem, lastID string, ch chan<- ActivityItem) string {
+	// Make sure the items are sorted by their identifier
+	sort.Slice(items, func(i, j int) bool { return items[i].ID < items[j].ID })
+	for i := range items {
+		if lastID == "" || items[i].ID > lastID {
+			ch <- items[i]
+			lastID = items[i].ID
+		}
+	}
+
+	return lastID
+}

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -76,13 +76,8 @@ func NewError(t ErrorType, resp *http.Response, body []byte) *Error {
 	}
 
 	// Capture the Retry-After header for "service unavailable"
-	if resp.StatusCode == http.StatusServiceUnavailable {
-		if ra, raerr := strconv.Atoi(resp.Header.Get("Retry-After")); raerr == nil {
-			if ra < 1 {
-				ra = 5
-			} else if ra > 120 {
-				ra = 120
-			}
+	if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusTooManyRequests {
+		if ra, _ := strconv.Atoi(resp.Header.Get("Retry-After")); ra > 0 {
 			err.RetryAfter = time.Duration(ra) * time.Second
 		}
 	}

--- a/pkg/api/experiments/v1alpha1/api.go
+++ b/pkg/api/experiments/v1alpha1/api.go
@@ -34,6 +34,12 @@ const (
 	ErrTrialAlreadyReported   api.ErrorType = "trial-already-reported"
 )
 
+// ExperimentName represents a name token used to identify an experiment.
+type ExperimentName interface {
+	// Name returns the string representation of the experiment name.
+	Name() string
+}
+
 type Server struct {
 	api.Metadata `json:"-"`
 }

--- a/pkg/api/experiments/v1alpha1/experiment.go
+++ b/pkg/api/experiments/v1alpha1/experiment.go
@@ -24,11 +24,6 @@ import (
 	"github.com/thestormforge/optimize-go/pkg/api"
 )
 
-// ExperimentName exists to clearly separate cases where an actual name can be used
-type ExperimentName interface {
-	Name() string
-}
-
 // NewExperimentName returns an experiment name for a given string
 func NewExperimentName(n string) ExperimentName {
 	return experimentName(n)

--- a/pkg/api/experiments/v1alpha1/parameter.go
+++ b/pkg/api/experiments/v1alpha1/parameter.go
@@ -22,63 +22,63 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
+	"github.com/thestormforge/optimize-go/pkg/api"
 )
 
 // LowerBound attempts to return the lower bound for this parameter.
-func (p *Parameter) LowerBound() (*numstr.NumberOrString, error) {
+func (p *Parameter) LowerBound() (*api.NumberOrString, error) {
 	if p.Type == ParameterTypeCategorical {
 		if len(p.Values) == 0 {
 			return nil, fmt.Errorf("unable to determine categorical minimum bound")
 		}
-		return &numstr.NumberOrString{StrVal: p.Values[0], IsString: true}, nil
+		return &api.NumberOrString{StrVal: p.Values[0], IsString: true}, nil
 	}
 
 	if p.Bounds == nil {
 		return nil, fmt.Errorf("unable to determine numeric minimum bound")
 	}
 
-	return &numstr.NumberOrString{NumVal: p.Bounds.Min}, nil
+	return &api.NumberOrString{NumVal: p.Bounds.Min}, nil
 }
 
 // UpperBound attempts to return the upper bound for this parameter.
-func (p *Parameter) UpperBound() (*numstr.NumberOrString, error) {
+func (p *Parameter) UpperBound() (*api.NumberOrString, error) {
 	if p.Type == ParameterTypeCategorical {
 		if len(p.Values) == 0 {
 			return nil, fmt.Errorf("unable to determine categorical maximum bound")
 		}
-		return &numstr.NumberOrString{StrVal: p.Values[len(p.Values)-1], IsString: true}, nil
+		return &api.NumberOrString{StrVal: p.Values[len(p.Values)-1], IsString: true}, nil
 	}
 
 	if p.Bounds == nil {
 		return nil, fmt.Errorf("unable to determine numeric maximum bound")
 	}
 
-	return &numstr.NumberOrString{NumVal: p.Bounds.Max}, nil
+	return &api.NumberOrString{NumVal: p.Bounds.Max}, nil
 }
 
 // ParseValue attempts to parse the supplied value into a NumberOrString based on the type of this parameter.
-func (p *Parameter) ParseValue(s string) (*numstr.NumberOrString, error) {
-	var v numstr.NumberOrString
+func (p *Parameter) ParseValue(s string) (*api.NumberOrString, error) {
+	var v api.NumberOrString
 	switch p.Type {
 	case ParameterTypeInteger:
 		if _, err := strconv.ParseInt(s, 10, 64); err != nil {
 			return nil, err
 		}
-		v = numstr.FromNumber(json.Number(s))
+		v = api.FromNumber(json.Number(s))
 	case ParameterTypeDouble:
 		if _, err := strconv.ParseFloat(s, 64); err != nil {
 			return nil, err
 		}
-		v = numstr.FromNumber(json.Number(s))
+		v = api.FromNumber(json.Number(s))
 	case ParameterTypeCategorical:
-		v = numstr.FromString(s)
+		v = api.FromString(s)
 	}
 	return &v, nil
 }
 
 // CheckParameterValue validates that the supplied value can be used for a parameter.
-func CheckParameterValue(p *Parameter, v *numstr.NumberOrString) error {
+func CheckParameterValue(p *Parameter, v *api.NumberOrString) error {
 	if p.Type == ParameterTypeCategorical {
 		if !v.IsString {
 			return fmt.Errorf("categorical value must be a string: %s", v.String())

--- a/pkg/api/experiments/v1alpha1/trial.go
+++ b/pkg/api/experiments/v1alpha1/trial.go
@@ -24,14 +24,13 @@ import (
 	"time"
 
 	"github.com/thestormforge/optimize-go/pkg/api"
-	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
 )
 
 type Assignment struct {
 	// The name of the parameter in the experiment the assignment corresponds to.
 	ParameterName string `json:"parameterName"`
 	// The assigned value of the parameter.
-	Value numstr.NumberOrString `json:"value"`
+	Value api.NumberOrString `json:"value"`
 }
 
 type TrialAssignments struct {

--- a/pkg/api/numorstr.go
+++ b/pkg/api/numorstr.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package numstr
+package api
 
 import (
 	"encoding/json"

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -65,6 +65,8 @@ type Server struct {
 
 // APIServer is the API server metadata
 type APIServer struct {
+	// ApplicationsEndpoint is the URL of the applications endpoint
+	ApplicationsEndpoint string `json:"applications_endpoint,omitempty"`
 	// ExperimentsEndpoint is the URL of the experiments endpoint
 	ExperimentsEndpoint string `json:"experiments_endpoint,omitempty"`
 	// AccountsEndpoint is the URL of the accounts endpoint

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -128,6 +128,7 @@ func defaultServerEndpoints(srv *Server) error {
 	}
 
 	// Apply the API defaults
+	defaultString(&srv.API.ApplicationsEndpoint, api+"/v2/applications/")
 	defaultString(&srv.API.ExperimentsEndpoint, api+"/v1/experiments/")
 	defaultString(&srv.API.AccountsEndpoint, api+"/v1/accounts/")
 


### PR DESCRIPTION
This is the rough in for the Application API Go client, I want to get it up rather than sit on it while it gets cleaned up. Basically, it mimics how the experiments API client works. I need to reconcile a bit around how "names" work because the old model does work as cleanly for the new model (where the name is part of the entity body); this same issue affects the way `Title` works so expect some clean up there as well.