### PR TITLE
Even more Application API

### DIFF
--- a/pkg/api/applications/v2/activity.go
+++ b/pkg/api/applications/v2/activity.go
@@ -70,8 +70,8 @@ type ActivityFeedQuery struct {
 	Query map[string][]string
 }
 
-func (q *ActivityFeedQuery) SetType(t string) {
-	url.Values(q.Query).Set("type", t)
+func (q *ActivityFeedQuery) SetType(t ...string) {
+	url.Values(q.Query).Set("type", strings.Join(t, ","))
 }
 
 type Activity struct {

--- a/pkg/api/applications/v2/activity.go
+++ b/pkg/api/applications/v2/activity.go
@@ -66,10 +66,12 @@ type Activity struct {
 }
 
 type RunActivity struct {
+	Scenario string `json:"scenario"`
 	ActivityFailure
 }
 
 type ScanActivity struct {
+	Scenario string `json:"scenario"`
 	ActivityFailure
 }
 

--- a/pkg/api/applications/v2/activity.go
+++ b/pkg/api/applications/v2/activity.go
@@ -18,6 +18,7 @@ package v2
 
 import (
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/thestormforge/optimize-go/pkg/api"
@@ -46,6 +47,20 @@ type ActivityItem struct {
 	Tags          []string           `json:"tags,omitempty"`
 	StormForge    *ActivityExtension `json:"_stormforge,omitempty"`
 }
+
+func (ai *ActivityItem) HasTag(tag string) bool {
+	for _, t := range ai.Tags {
+		if strings.EqualFold(t, tag) {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	TagRun  string = "run"
+	TagScan string = "scan"
+)
 
 type ActivityExtension struct {
 	ActivityFailure

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -23,24 +23,24 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/thestormforge/optimize-go/pkg/api"
 )
 
-const endpointApplications = "/v2/applications/"
-
 func NewAPI(c api.Client) API {
-	return &httpAPI{client: c}
+	return &httpAPI{client: c, endpoint: "v2/applications/"}
 }
 
 type httpAPI struct {
-	client api.Client
+	client   api.Client
+	endpoint string
 }
 
 var _ API = &httpAPI{}
 
 func (h *httpAPI) ListApplications(ctx context.Context, q ApplicationListQuery) (ApplicationList, error) {
-	u := h.client.URL(endpointApplications)
+	u := h.client.URL(h.endpoint)
 	u.RawQuery = url.Values(q.IndexQuery).Encode()
 
 	return h.ListApplicationsByPage(ctx, u.String())
@@ -70,7 +70,7 @@ func (h *httpAPI) ListApplicationsByPage(ctx context.Context, u string) (Applica
 }
 
 func (h *httpAPI) CreateApplication(ctx context.Context, app Application) (api.Metadata, error) {
-	u := h.client.URL(endpointApplications).String()
+	u := h.client.URL(h.endpoint).String()
 
 	req, err := httpNewJSONRequest(http.MethodPost, u, app)
 	if err != nil {
@@ -120,7 +120,7 @@ func (h *httpAPI) GetApplication(ctx context.Context, u string) (Application, er
 }
 
 func (h *httpAPI) GetApplicationByName(ctx context.Context, n ApplicationName) (Application, error) {
-	u := h.client.URL(endpointApplications + n.String()).String()
+	u := h.client.URL(path.Join(h.endpoint, n.String())).String()
 	result, err := h.GetApplication(ctx, u)
 
 	// Improve the "not found" error message using the name
@@ -155,7 +155,7 @@ func (h *httpAPI) UpsertApplication(ctx context.Context, u string, app Applicati
 }
 
 func (h *httpAPI) UpsertApplicationByName(ctx context.Context, n ApplicationName, app Application) (api.Metadata, error) {
-	u := h.client.URL(endpointApplications + n.String()).String()
+	u := h.client.URL(path.Join(h.endpoint, n.String())).String()
 	return h.UpsertApplication(ctx, u, app)
 }
 

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -32,26 +32,32 @@ func TestHttpClient_URL(t *testing.T) {
 		{
 			desc:     "standard",
 			address:  "https://example.com/",
-			endpoint: "/v1/experiments/",
+			endpoint: "v1/experiments/",
 			url:      "https://example.com/v1/experiments/",
 		},
 		{
 			desc:     "named resource endpoint",
 			address:  "https://example.com/",
-			endpoint: "/v1/experiments/foobar",
+			endpoint: "v1/experiments/foobar",
 			url:      "https://example.com/v1/experiments/foobar",
 		},
 		{
 			desc:     "trailing address slash",
 			address:  "https://example.com/foobar/",
-			endpoint: "/v1/experiments/",
+			endpoint: "v1/experiments/",
 			url:      "https://example.com/foobar/v1/experiments/",
 		},
 		{
 			desc:     "no base path",
 			address:  "https://example.com",
-			endpoint: "/v1/experiments/",
+			endpoint: "v1/experiments/",
 			url:      "https://example.com/v1/experiments/",
+		},
+		{
+			desc:     "fully qualified endpoint",
+			address:  "https://example.com/",
+			endpoint: "https://invalid.example.com/v2/applications/foobar/experiments/",
+			url:      "https://invalid.example.com/v2/applications/foobar/experiments/",
 		},
 	}
 	for _, c := range cases {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -71,3 +71,29 @@ func (q *IndexQuery) SetLabelSelector(kv map[string]string) {
 		url.Values(*q).Add(ParamLabelSelector, strings.Join(ls, ","))
 	}
 }
+
+// AppendToURL adds this index query to an existing URL.
+func (q *IndexQuery) AppendToURL(u string) (string, error) {
+	if q == nil || len(*q) == 0 {
+		return u, nil
+	}
+
+	uu, err := url.Parse(u)
+	if err != nil {
+		return "", err
+	}
+
+	qq, err := url.ParseQuery(uu.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	for k, v := range *q {
+		for _, vv := range v {
+			qq.Add(k, vv)
+		}
+	}
+	uu.RawQuery = qq.Encode()
+
+	return uu.String(), nil
+}

--- a/pkg/api/index_test.go
+++ b/pkg/api/index_test.go
@@ -57,3 +57,71 @@ func TestIndexQuery_nil(t *testing.T) {
 	assert.NotNil(t, q)
 	assert.Equal(t, []string{"97"}, q[ParamLimit])
 }
+
+func TestIndexQuery_AppendToURL(t *testing.T) {
+	cases := []struct {
+		desc     string
+		q        *IndexQuery
+		u        string
+		expected string
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc:     "empty query",
+			q:        &IndexQuery{},
+			u:        "foobar",
+			expected: "foobar",
+		},
+		{
+			desc: "relative URL",
+			q: &IndexQuery{
+				"offset": []string{"10"},
+			},
+			u:        "foobar",
+			expected: "foobar?offset=10",
+		},
+		{
+			desc: "qualified URL",
+			q: &IndexQuery{
+				"offset": []string{"10"},
+			},
+			u:        "https://example.com/foobar/",
+			expected: "https://example.com/foobar/?offset=10",
+		},
+		{
+			desc: "query merges",
+			q: &IndexQuery{
+				"offset": []string{"10"},
+			},
+			u:        "https://example.com/foobar/?limit=20",
+			expected: "https://example.com/foobar/?limit=20&offset=10",
+		},
+		{
+			desc: "query appends",
+			q: &IndexQuery{
+				"limit": []string{"10"},
+			},
+			u:        "https://example.com/foobar/?limit=20",
+			expected: "https://example.com/foobar/?limit=20&limit=10",
+		},
+		{
+			desc: "multiple parameters",
+			q: &IndexQuery{
+				"limit":  []string{"10"},
+				"offset": []string{"30"},
+			},
+			u:        "https://example.com/foobar",
+			expected: "https://example.com/foobar?limit=10&offset=30",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			u, err := c.q.AppendToURL(c.u)
+			if assert.NoError(t, err) {
+				assert.Equal(t, c.expected, u)
+			}
+		})
+	}
+}

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -30,11 +30,13 @@ const (
 	RelationNext        = "next"
 	RelationPrev        = "prev"
 	RelationAlternate   = "alternate"
+	RelationUp          = "up"
 	RelationLabels      = "https://stormforge.io/rel/labels"
 	RelationTrials      = "https://stormforge.io/rel/trials"
 	RelationNextTrial   = "https://stormforge.io/rel/next-trial"
 	RelationScenarios   = "https://stormforge.io/rel/scenarios"
 	RelationExperiments = "https://stormforge.io/rel/experiments"
+	RelationScan        = "https://stormforge.io/rel/scan"
 )
 
 // Metadata is used to hold single or multi-value metadata from list responses.
@@ -107,6 +109,10 @@ func CanonicalLinkRelation(rel string) string {
 	case "https://carbonrelay.com/rel/next-trial",
 		"https://carbonrelay.com/rel/nexttrial":
 		return RelationNextTrial
+
+	case "https://stormforge.io/rel/application":
+		// TODO This probably isn't necessary as it was pre-release software
+		return RelationUp
 
 	default:
 		return rel


### PR DESCRIPTION
This PR addresses a few gaps in the Application API:
* The endpoint URL is not configurable, this is necessary to "re-home" the existing Experiments API on top of the Application API. As fallout from this, I made use of more specific URL functions rather then relying on string manipulation. This also address an edge case for testing where you can inject query parameters to the base URL.
* Added some missing relations.
* Added a helper to test for activity item tags to help with some awkwardness of using standard JSON feed.