### PR TITLE
feat: Add CheckEndpoint to apis

### DIFF
--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -39,6 +39,9 @@ type Subscriber interface {
 }
 
 type API interface {
+	// CheckEndpoint verifies we can talk to the backend.
+	CheckEndpoint(ctx context.Context) (api.Metadata, error)
+
 	// ListApplications gets a list of existing applications for an authorized request.
 	ListApplications(ctx context.Context, q ApplicationListQuery) (ApplicationList, error)
 	// ListApplicationsByPage returns single page of applications identified by the supplied URL.

--- a/pkg/api/experiments/v1alpha1/api.go
+++ b/pkg/api/experiments/v1alpha1/api.go
@@ -40,7 +40,8 @@ type Server struct {
 
 // API provides bindings for the supported endpoints
 type API interface {
-	Options(context.Context) (Server, error)
+	// CheckEndpoint verifies we can talk to the backend.
+	CheckEndpoint(ctx context.Context) (api.Metadata, error)
 
 	GetAllExperiments(context.Context, ExperimentListQuery) (ExperimentList, error)
 	GetAllExperimentsByPage(context.Context, string) (ExperimentList, error)


### PR DESCRIPTION
This adds in a CheckEndpoint method that issues a HEAD request to
our APIs to verify we can talk to them properly.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>