### PR TITLE
First pass at an application integration test

### DIFF
--- a/pkg/api/applications/v2/api_test.go
+++ b/pkg/api/applications/v2/api_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2_test
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thestormforge/optimize-go/pkg/api"
+	applications "github.com/thestormforge/optimize-go/pkg/api/applications/v2"
+	experiments "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	"github.com/thestormforge/optimize-go/pkg/api/internal/apitest"
+)
+
+var (
+	client api.Client
+	cases  []apitest.ApplicationTestDefinition
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	path := "testdata"
+	flag.Parse()
+
+	// Create a client
+	client, err = apitest.NewClient(context.TODO())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Load the test data
+	cases, err = apitest.ReadApplicationTestData(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Execute the tests
+	os.Exit(m.Run())
+}
+
+func TestAPI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping API test in short mode.")
+	}
+
+	appAPI := applications.NewAPI(client)
+
+	for i := range cases {
+		t.Run(cases[i].Application.DisplayName, func(t *testing.T) {
+			runTest(t, &cases[i], appAPI)
+		})
+	}
+}
+
+func runTest(t *testing.T, td *apitest.ApplicationTestDefinition, appAPI applications.API) {
+	ctx := context.Background()
+	var appMeta, scnMeta api.Metadata
+	var run sync.WaitGroup
+	subCtx, cancelSub := context.WithCancel(ctx)
+	activity := make(chan applications.ActivityItem)
+
+	t.Run("Subscribe", func(t *testing.T) {
+		q := applications.ActivityFeedQuery{}
+		q.SetType(applications.TagScan, applications.TagRun)
+		sub, err := appAPI.SubscribeActivity(subCtx, q)
+		if assert.NoError(t, err, "failed to create activity subscriber") {
+			sub.Subscribe(ctx, activity)
+		} else {
+			close(activity)
+		}
+	})
+
+	ok := t.Run("Create Application", func(t *testing.T) {
+		var err error
+		appMeta, err = appAPI.CreateApplication(ctx, td.Application)
+		require.NoError(t, err, "failed to create application")
+		assert.NotEmpty(t, appMeta.Location(), "missing location")
+		assert.NotEmpty(t, appMeta.Link(api.RelationScenarios), "missing scenarios link")
+		assert.Equal(t, td.Application.DisplayName, appMeta.Title(), "title metadata does not match")
+	})
+
+	ok = t.Run("Create Scenario", func(t *testing.T) {
+		if !ok {
+			t.Skip("skipping scenario.")
+		}
+
+		var err error
+		scnMeta, err = appAPI.CreateScenario(ctx, appMeta.Link(api.RelationScenarios), td.Scenario)
+		require.NoError(t, err, "failed to create scenario")
+		assert.NotEmpty(t, scnMeta.Location(), "missing location")
+		assert.NotEmpty(t, scnMeta.Link(api.RelationScan), "missing scan link")
+		assert.Equal(t, appMeta.Location(), scnMeta.Link(api.RelationUp), "application link does not match")
+		assert.Equal(t, td.Scenario.DisplayName, scnMeta.Title(), "title metadata does not match")
+	})
+
+	t.Run("Handle Activity", func(t *testing.T) {
+		t.Parallel()
+		if !ok {
+			t.Skip("skipping activity handling.")
+		}
+
+		for ai := range activity {
+			// NOTE: We limited the activity types when we subscribed
+			assert.True(t, ai.HasTag(applications.TagScan) || ai.HasTag(applications.TagRun), "unexpected item tag")
+
+			// Both scan and run use the external URL to point at the scenario
+			scn, err := appAPI.GetScenario(ctx, ai.ExternalURL)
+			require.NoError(t, err, "failed to retrieve activity scenario")
+			require.NotEmpty(t, scn.Link(api.RelationScan), "missing scan link")
+			require.NotEmpty(t, scn.Link(api.RelationExperiments), "missing experiments link")
+			require.NotEmpty(t, scn.Link(api.RelationUp), "missing application link")
+
+			app, err := appAPI.GetApplication(ctx, scn.Link(api.RelationUp))
+			require.NoError(t, err, "failed to retrieve scenario application")
+
+			switch {
+
+			case ai.HasTag(applications.TagScan):
+				t.Run("Scan", func(t *testing.T) {
+					err = appAPI.UpdateScan(ctx, scn.Link(api.RelationScan), td.GenerateScan())
+					require.NoError(t, err, "failed to update scan")
+				})
+
+			case ai.HasTag(applications.TagRun):
+				t.Run("Run", func(t *testing.T) {
+					defer run.Done()
+
+					// Discard the scan for the test, the defined experiment is fixed
+					_, err = appAPI.GetScan(ctx, scn.Link(api.RelationScan))
+					require.NoError(t, err, "failed to retrieve scenario scan")
+
+					expAPI, err := experiments.NewAPIWithEndpoint(client, scn.Link(api.RelationExperiments))
+					require.NoError(t, err, "failed to create experiment API for application")
+
+					exp, err := expAPI.CreateExperimentByName(ctx, td.ExperimentName, td.Experiment)
+					require.NoError(t, err, "failed to create experiment")
+					assert.NotEmpty(t, exp.Link(api.RelationTrials), "missing trials link")
+					assert.NotEmpty(t, exp.Link(api.RelationNextTrial), "missing next trial link")
+					assert.NotEmpty(t, exp.Link(api.RelationSelf), "missing self link")
+					assert.Equal(t, app.Name, exp.Labels["application"], "incorrect application label")
+					assert.Equal(t, scn.Name, exp.Labels["scenario"], "incorrect scenario label")
+
+					_, err = expAPI.CreateTrial(ctx, exp.Link(api.RelationTrials), experiments.TrialAssignments{
+						Labels:      map[string]string{"baseline": "true"},
+						Assignments: td.Baseline,
+					})
+					require.NoError(t, err, "failed to create baseline trial")
+
+					for {
+						ta, err := expAPI.NextTrial(ctx, exp.Link(api.RelationNextTrial))
+						var aerr *api.Error
+						if errors.As(err, &aerr) && aerr.Type == experiments.ErrExperimentStopped {
+							break
+						}
+						require.NoError(t, err, "failed to fetch trial assignments")
+						assert.NotEmpty(t, ta.Location(), "missing location")
+
+						err = expAPI.ReportTrial(ctx, ta.Location(), td.TrialResults(&ta))
+						require.NoError(t, err, "failed to report trial")
+					}
+				})
+			}
+
+			err = appAPI.DeleteActivity(ctx, ai.URL)
+			require.NoError(t, err, "failed to acknowledge activity")
+		}
+	})
+
+	t.Run("Request Activity", func(t *testing.T) {
+		if !ok {
+			t.Skip("skipping activity request.")
+		}
+
+		// TODO This should use CheckEndpoint to get the feed link via a HEAD request
+		lst, err := appAPI.ListApplications(ctx, applications.ApplicationListQuery{})
+		require.NoError(t, err, "failed to fetch the application list necessary for the feed URL")
+
+		// TODO Do we need to create this or is it implicit from create scenario?
+		sa := &applications.ScanActivity{
+			Scenario: scnMeta.Location(),
+		}
+		err = appAPI.CreateActivity(ctx, lst.Link(api.RelationAlternate), applications.Activity{Scan: sa})
+		require.NoError(t, err, "failed to request scan")
+
+		ra := &applications.RunActivity{
+			Scenario: scnMeta.Location(),
+		}
+		err = appAPI.CreateActivity(ctx, lst.Link(api.RelationAlternate), applications.Activity{Run: ra})
+		require.NoError(t, err, "failed to request run")
+		run.Add(1)
+	})
+
+	// Wait for all run activities to finish
+	run.Wait()
+	cancelSub()
+
+	t.Run("Delete Application", func(t *testing.T) {
+		if appMeta.Location() == "" {
+			t.Skip("skipping delete application.")
+		}
+
+		err := appAPI.DeleteApplication(ctx, appMeta.Location())
+		require.NoError(t, err, "failed to delete application")
+
+		// TODO Verify the experiment still exists via the /v1/experiments/ endpoint? Or will it be deleted?
+	})
+}

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -498,7 +498,7 @@ func (h *httpAPI) UpdateApplicationActivity(ctx context.Context, u string, a Act
 }
 
 func (h *httpAPI) SubscribeActivity(ctx context.Context, q ActivityFeedQuery) (Subscriber, error) {
-	// TODO This should be a HEAD request
+	// TODO This should use CheckEndpoint to get the feed link via a HEAD request
 	lst, err := h.ListApplications(ctx, ApplicationListQuery{})
 	if err != nil {
 		return nil, err

--- a/pkg/api/applications/v2/testdata/my-app.json
+++ b/pkg/api/applications/v2/testdata/my-app.json
@@ -1,0 +1,87 @@
+{
+  "Application": {
+    "title": "My App",
+    "resources": [
+      {
+        "namespace": "default",
+        "selector": "app.kubernetes.io/name=my-app"
+      }
+    ]
+  },
+  "Scenario": {
+    "title": "Black Friday",
+    "configuration": [
+      {
+        "containerResources": {
+          "selector": "app.kubernetes.io/component in (api,db,worker)"
+        }
+      },
+      {
+        "replicas": {
+          "selector": "app.kubernetes.io/component in (api,worker)"
+        }
+      }
+    ],
+    "objective": [
+      {
+        "name": "cost"
+      },
+      {
+        "name": "p95-latency"
+      }
+    ],
+    "stormforger": {
+      "testCase": "myorg/large-load-test"
+    }
+  },
+  "Experiment": {
+    "optimization": [
+      {
+        "name": "experimentBudget",
+        "value": "20"
+      }
+    ],
+    "parameters": [
+      {
+        "name": "cpu",
+        "type": "int",
+        "bounds": {
+          "min": 2000,
+          "max": 4000
+        }
+      },
+      {
+        "name": "memory",
+        "type": "int",
+        "bounds": {
+          "min": 2048,
+          "max": 4096
+        }
+      }
+    ],
+    "metrics": [
+      {
+        "name": "cost",
+        "minimize": true
+      },
+      {
+        "name": "duration",
+        "minimize": true
+      }
+    ]
+  },
+  "Baseline": [
+    {
+      "parameterName": "cpu",
+      "value": 4000
+    },
+    {
+      "parameterName": "memory",
+      "value": 4096
+    }
+  ],
+  "Values": [
+    [0.017, 0.002],
+    [0.00003, -0.0005]
+  ]
+}

--- a/pkg/api/internal/apitest/applications.go
+++ b/pkg/api/internal/apitest/applications.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apitest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	applications "github.com/thestormforge/optimize-go/pkg/api/applications/v2"
+)
+
+// ApplicationTestDefinition is used to define tests to run against an application API implementation.
+type ApplicationTestDefinition struct {
+	Application applications.Application
+	Scenario    applications.Scenario
+
+	// In addition to the application and scenario, we need an experiment.
+	ExperimentTestDefinition
+}
+
+// GenerateScan returns details of experiment for this test definition.
+func (td *ApplicationTestDefinition) GenerateScan() applications.Scan {
+	result := applications.Scan{
+		Parameters: make([]applications.ScanParameter, 0, len(td.Experiment.Parameters)),
+		Metrics:    make([]applications.ScanMetric, 0, len(td.Experiment.Metrics)),
+	}
+
+	for _, p := range td.Experiment.Parameters {
+		sp := applications.ScanParameter{
+			Name:   p.Name,
+			Type:   string(p.Type),
+			Values: p.Values,
+		}
+		if p.Bounds != nil {
+			sp.Bounds = &applications.ScanParameterBounds{
+				Min: p.Bounds.Min,
+				Max: p.Bounds.Max,
+			}
+		}
+		for _, b := range td.Baseline {
+			if b.ParameterName == p.Name {
+				sp.Baseline = &b.Value
+			}
+		}
+		result.Parameters = append(result.Parameters, sp)
+	}
+
+	for _, m := range td.Experiment.Metrics {
+		sm := applications.ScanMetric{
+			Name:     m.Name,
+			Minimize: m.Minimize,
+			Optimize: m.Optimize,
+		}
+		// TODO Where do we get the metric bounds from?
+		result.Metrics = append(result.Metrics, sm)
+	}
+
+	return result
+}
+
+// ReadApplicationTestData reads all of the JSON files in the supplied test data directory.
+func ReadApplicationTestData(path string) ([]ApplicationTestDefinition, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read test data directory %q: %w", path, err)
+	}
+
+	var result []ApplicationTestDefinition
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		data, err := ioutil.ReadFile(filepath.Join(path, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read test data %q: %w", entry.Name(), err)
+		}
+
+		td := ApplicationTestDefinition{}
+		if err := json.Unmarshal(data, &td); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal test definition: %w", err)
+		}
+
+		td.ExperimentTestDefinition.ExperimentName = "" // TODO Make a new ULID here
+
+		result = append(result, td)
+	}
+	return result, nil
+}

--- a/pkg/api/internal/apitest/applications.go
+++ b/pkg/api/internal/apitest/applications.go
@@ -98,8 +98,6 @@ func ReadApplicationTestData(path string) ([]ApplicationTestDefinition, error) {
 			return nil, fmt.Errorf("failed to unmarshal test definition: %w", err)
 		}
 
-		td.ExperimentTestDefinition.ExperimentName = "" // TODO Make a new ULID here
-
 		result = append(result, td)
 	}
 	return result, nil


### PR DESCRIPTION
This is an as-of-yet-unrun test to help verify the anticipated controller usage of the application API using the Go client.

This test works the same way as the #30 integration test does for experiments. Note that you can run against an unprotected endpoint (e.g. a local deployment) by omitting the credential options if necessary (or you can directly specify the bearer token).