### PR TITLE
Remove application relation

### DIFF
--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -110,10 +110,6 @@ func CanonicalLinkRelation(rel string) string {
 		"https://carbonrelay.com/rel/nexttrial":
 		return RelationNextTrial
 
-	case "https://stormforge.io/rel/application":
-		// TODO This probably isn't necessary as it was pre-release software
-		return RelationUp
-
 	default:
 		return rel
 	}


### PR DESCRIPTION
I had left something in to support the `.../application` relation, but it's not necessary since we are just going with `up`.