### PR TITLE
Rename scenario scan to template

### DIFF
--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -69,12 +69,12 @@ type API interface {
 	// PatchScenario updates attributes on a scenario.
 	PatchScenario(ctx context.Context, u string, scn Scenario) error
 
-	// GetScan gets application scenario scan.
-	GetScan(ctx context.Context, u string) (Scan, error)
-	// UpdateScan records or updates cluster scan results.
-	UpdateScan(ctx context.Context, u string, s Scan) error
-	// PatchScan updates partial cluster scan results.
-	PatchScan(ctx context.Context, u string, s Scan) error
+	// GetTemplate gets the application scenario template.
+	GetTemplate(ctx context.Context, u string) (Template, error)
+	// UpdateTemplate records or updates scenario template.
+	UpdateTemplate(ctx context.Context, u string, s Template) error
+	// PatchTemplate updates a partial scenario template.
+	PatchTemplate(ctx context.Context, u string, s Template) error
 
 	// ListActivity gets activity feed for an application.
 	ListActivity(ctx context.Context, u string, q ActivityFeedQuery) (ActivityFeed, error)

--- a/pkg/api/applications/v2/api_test.go
+++ b/pkg/api/applications/v2/api_test.go
@@ -113,7 +113,7 @@ func runTest(t *testing.T, td *apitest.ApplicationTestDefinition, appAPI applica
 		scnMeta, err = appAPI.CreateScenario(ctx, appMeta.Link(api.RelationScenarios), td.Scenario)
 		require.NoError(t, err, "failed to create scenario")
 		assert.NotEmpty(t, scnMeta.Location(), "missing location")
-		assert.NotEmpty(t, scnMeta.Link(api.RelationScan), "missing scan link")
+		assert.NotEmpty(t, scnMeta.Link(api.RelationTemplate), "missing template link")
 		assert.Equal(t, appMeta.Location(), scnMeta.Link(api.RelationUp), "application link does not match")
 		assert.Equal(t, td.Scenario.DisplayName, scnMeta.Title(), "title metadata does not match")
 	})
@@ -131,7 +131,7 @@ func runTest(t *testing.T, td *apitest.ApplicationTestDefinition, appAPI applica
 			// Both scan and run use the external URL to point at the scenario
 			scn, err := appAPI.GetScenario(ctx, ai.ExternalURL)
 			require.NoError(t, err, "failed to retrieve activity scenario")
-			require.NotEmpty(t, scn.Link(api.RelationScan), "missing scan link")
+			require.NotEmpty(t, scn.Link(api.RelationTemplate), "missing template link")
 			require.NotEmpty(t, scn.Link(api.RelationExperiments), "missing experiments link")
 			require.NotEmpty(t, scn.Link(api.RelationUp), "missing application link")
 
@@ -142,17 +142,17 @@ func runTest(t *testing.T, td *apitest.ApplicationTestDefinition, appAPI applica
 
 			case ai.HasTag(applications.TagScan):
 				t.Run("Scan", func(t *testing.T) {
-					err = appAPI.UpdateScan(ctx, scn.Link(api.RelationScan), td.GenerateScan())
-					require.NoError(t, err, "failed to update scan")
+					err = appAPI.UpdateTemplate(ctx, scn.Link(api.RelationTemplate), td.GenerateTemplate())
+					require.NoError(t, err, "failed to update template")
 				})
 
 			case ai.HasTag(applications.TagRun):
 				t.Run("Run", func(t *testing.T) {
 					defer run.Done()
 
-					// Discard the scan for the test, the defined experiment is fixed
-					_, err = appAPI.GetScan(ctx, scn.Link(api.RelationScan))
-					require.NoError(t, err, "failed to retrieve scenario scan")
+					// Discard the template for the test, the defined experiment is fixed
+					_, err = appAPI.GetTemplate(ctx, scn.Link(api.RelationTemplate))
+					require.NoError(t, err, "failed to retrieve scenario template")
 
 					expAPI, err := experiments.NewAPIWithEndpoint(client, scn.Link(api.RelationExperiments))
 					require.NoError(t, err, "failed to create experiment API for application")

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -320,8 +320,8 @@ func (h *httpAPI) PatchScenario(ctx context.Context, u string, scn Scenario) err
 	}
 }
 
-func (h *httpAPI) GetScan(ctx context.Context, u string) (Scan, error) {
-	result := Scan{}
+func (h *httpAPI) GetTemplate(ctx context.Context, u string) (Template, error) {
+	result := Template{}
 
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
@@ -342,8 +342,8 @@ func (h *httpAPI) GetScan(ctx context.Context, u string) (Scan, error) {
 	}
 }
 
-func (h *httpAPI) UpdateScan(ctx context.Context, u string, s Scan) error {
-	req, err := httpNewJSONRequest(http.MethodPut, u, s)
+func (h *httpAPI) UpdateTemplate(ctx context.Context, u string, t Template) error {
+	req, err := httpNewJSONRequest(http.MethodPut, u, t)
 	if err != nil {
 		return err
 	}
@@ -365,8 +365,8 @@ func (h *httpAPI) UpdateScan(ctx context.Context, u string, s Scan) error {
 	}
 }
 
-func (h *httpAPI) PatchScan(ctx context.Context, u string, s Scan) error {
-	req, err := httpNewJSONRequest(http.MethodPatch, u, s)
+func (h *httpAPI) PatchTemplate(ctx context.Context, u string, t Template) error {
+	req, err := httpNewJSONRequest(http.MethodPatch, u, t)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/applications/v2/scenario.go
+++ b/pkg/api/applications/v2/scenario.go
@@ -54,14 +54,14 @@ type ScenarioList struct {
 	Scenarios []ScenarioItem `json:"scenarios,omitempty"`
 }
 
-type ScanParameterBounds struct {
+type TemplateParameterBounds struct {
 	// The minimum value for a numeric parameter.
 	Min json.Number `json:"min,omitempty"`
 	// The maximum value for a numeric parameter.
 	Max json.Number `json:"max,omitempty"`
 }
 
-type ScanParameter struct {
+type TemplateParameter struct {
 	// The name of the parameter.
 	Name string `json:"name"`
 	// The type of the parameter.
@@ -69,19 +69,19 @@ type ScanParameter struct {
 	// The optional baseline value of the parameter, either numeric or categorical.
 	Baseline *api.NumberOrString `json:"baseline,omitempty"`
 	// The domain of the parameter.
-	Bounds *ScanParameterBounds `json:"bounds,omitempty"`
+	Bounds *TemplateParameterBounds `json:"bounds,omitempty"`
 	// The list of allowed categorical values for the parameter.
 	Values []string `json:"values,omitempty"`
 }
 
-type ScanMetricBounds struct {
+type TemplateMetricBounds struct {
 	// The minimum value for a metric.
 	Min float64 `json:"min,omitempty"`
 	// The maximum value for a metric.
 	Max float64 `json:"max,omitempty"`
 }
 
-type ScanMetric struct {
+type TemplateMetric struct {
 	// The name of the metric.
 	Name string `json:"name"`
 	// The flag indicating this metric should be minimized.
@@ -89,12 +89,12 @@ type ScanMetric struct {
 	// The flag indicating this metric is optimized (nil defaults to true).
 	Optimize *bool `json:"optimize,omitempty"`
 	// The domain of the metric
-	Bounds *ScanMetricBounds `json:"bounds,omitempty"`
+	Bounds *TemplateMetricBounds `json:"bounds,omitempty"`
 }
 
-type Scan struct {
-	// The list of parameters for this scan.
-	Parameters []ScanParameter `json:"parameters,omitempty"`
-	// The list of metrics for this scan.
-	Metrics []ScanMetric `json:"metrics,omitempty"`
+type Template struct {
+	// The list of parameters for this template.
+	Parameters []TemplateParameter `json:"parameters,omitempty"`
+	// The list of metrics for this template.
+	Metrics []TemplateMetric `json:"metrics,omitempty"`
 }

--- a/pkg/api/internal/apitest/applications.go
+++ b/pkg/api/internal/apitest/applications.go
@@ -35,21 +35,21 @@ type ApplicationTestDefinition struct {
 	ExperimentTestDefinition
 }
 
-// GenerateScan returns details of experiment for this test definition.
-func (td *ApplicationTestDefinition) GenerateScan() applications.Scan {
-	result := applications.Scan{
-		Parameters: make([]applications.ScanParameter, 0, len(td.Experiment.Parameters)),
-		Metrics:    make([]applications.ScanMetric, 0, len(td.Experiment.Metrics)),
+// GenerateTemplate returns details of experiment for this test definition.
+func (td *ApplicationTestDefinition) GenerateTemplate() applications.Template {
+	result := applications.Template{
+		Parameters: make([]applications.TemplateParameter, 0, len(td.Experiment.Parameters)),
+		Metrics:    make([]applications.TemplateMetric, 0, len(td.Experiment.Metrics)),
 	}
 
 	for _, p := range td.Experiment.Parameters {
-		sp := applications.ScanParameter{
+		sp := applications.TemplateParameter{
 			Name:   p.Name,
 			Type:   string(p.Type),
 			Values: p.Values,
 		}
 		if p.Bounds != nil {
-			sp.Bounds = &applications.ScanParameterBounds{
+			sp.Bounds = &applications.TemplateParameterBounds{
 				Min: p.Bounds.Min,
 				Max: p.Bounds.Max,
 			}
@@ -63,7 +63,7 @@ func (td *ApplicationTestDefinition) GenerateScan() applications.Scan {
 	}
 
 	for _, m := range td.Experiment.Metrics {
-		sm := applications.ScanMetric{
+		sm := applications.TemplateMetric{
 			Name:     m.Name,
 			Minimize: m.Minimize,
 			Optimize: m.Optimize,

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -36,7 +36,7 @@ const (
 	RelationNextTrial   = "https://stormforge.io/rel/next-trial"
 	RelationScenarios   = "https://stormforge.io/rel/scenarios"
 	RelationExperiments = "https://stormforge.io/rel/experiments"
-	RelationScan        = "https://stormforge.io/rel/scan"
+	RelationTemplate    = "https://stormforge.io/rel/template"
 )
 
 // Metadata is used to hold single or multi-value metadata from list responses.


### PR DESCRIPTION
This PR updates the "scan" resource to "template". The PR is based off #36 to avoid conflicts.

Note that I did not rename the activity, "scan" still seems to fit there.