### PR TITLE
App API clean up

### DIFF
--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -85,10 +85,8 @@ type API interface {
 	CreateActivity(ctx context.Context, u string, a Activity) error
 	// DeleteActivity resolves application activity.
 	DeleteActivity(ctx context.Context, u string) error
-	// GetApplicationActivity retrieves an application activity item by ID.
-	GetApplicationActivity(ctx context.Context, u string) (Activity, error)
-	// UpdateApplicationActivity updates application activity.
-	UpdateApplicationActivity(ctx context.Context, u string, a Activity) error
+	// PatchApplicationActivity updates application activity.
+	PatchApplicationActivity(ctx context.Context, u string, a ActivityFailure) error
 
 	// SubscribeActivity returns a subscriber for the activity feed.
 	SubscribeActivity(ctx context.Context, q ActivityFeedQuery) (Subscriber, error)

--- a/pkg/api/applications/v2/api_test.go
+++ b/pkg/api/applications/v2/api_test.go
@@ -195,6 +195,7 @@ func runTest(t *testing.T, td *apitest.ApplicationTestDefinition, appAPI applica
 	})
 
 	t.Run("Request Activity", func(t *testing.T) {
+		t.Parallel()
 		if !ok {
 			t.Skip("skipping activity request.")
 		}

--- a/pkg/api/applications/v2/api_test.go
+++ b/pkg/api/applications/v2/api_test.go
@@ -89,6 +89,9 @@ func runTest(t *testing.T, td *apitest.ApplicationTestDefinition, appAPI applica
 		q.SetType(applications.TagScan, applications.TagRun)
 		sub, err := appAPI.SubscribeActivity(subCtx, q)
 		if assert.NoError(t, err, "failed to create activity subscriber") {
+			if ps, ok := sub.(*applications.PollingSubscriber); ok {
+				ps.PollInterval = 3 * time.Second
+			}
 			sub.Subscribe(ctx, activity)
 		} else {
 			close(activity)

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -488,33 +488,8 @@ func (h *httpAPI) DeleteActivity(ctx context.Context, u string) error {
 	}
 }
 
-func (h *httpAPI) GetApplicationActivity(ctx context.Context, u string) (Activity, error) {
-	result := Activity{}
-
-	req, err := http.NewRequest(http.MethodGet, u, nil)
-	if err != nil {
-		return result, err
-	}
-
-	resp, body, err := h.client.Do(ctx, req)
-	if err != nil {
-		return result, err
-	}
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		api.UnmarshalMetadata(resp, &result.Metadata)
-		err = json.Unmarshal(body, &result)
-		return result, err
-	case http.StatusTooManyRequests:
-		return result, api.NewError(ErrActivityRateLimited, resp, body)
-	default:
-		return result, api.NewUnexpectedError(resp, body)
-	}
-}
-
-func (h *httpAPI) UpdateApplicationActivity(ctx context.Context, u string, a Activity) error {
-	req, err := httpNewJSONRequest(http.MethodPut, u, a)
+func (h *httpAPI) PatchApplicationActivity(ctx context.Context, u string, a ActivityFailure) error {
+	req, err := httpNewJSONRequest(http.MethodPatch, u, a)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -508,14 +508,13 @@ func (h *httpAPI) PatchApplicationActivity(ctx context.Context, u string, a Acti
 }
 
 func (h *httpAPI) SubscribeActivity(ctx context.Context, q ActivityFeedQuery) (Subscriber, error) {
-	// TODO This should use CheckEndpoint to get the feed link via a HEAD request
-	lst, err := h.ListApplications(ctx, ApplicationListQuery{})
+	md, err := h.CheckEndpoint(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO Also filter on `type=application/feed+json`
-	u := lst.Link(api.RelationAlternate)
+	u := md.Link(api.RelationAlternate)
 	if u == "" {
 		return nil, fmt.Errorf("missing activity feed URL")
 	}

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -550,7 +550,7 @@ func (h *httpAPI) SubscribeActivity(ctx context.Context, q ActivityFeedQuery) (S
 		return nil, err
 	}
 
-	return NewSubscriber(h, feed), nil
+	return newSubscriber(h, feed), nil
 }
 
 // httpNewJSONRequest returns a new HTTP request with a JSON payload

--- a/pkg/api/applications/v2/subscribe.go
+++ b/pkg/api/applications/v2/subscribe.go
@@ -26,8 +26,8 @@ import (
 	"github.com/thestormforge/optimize-go/pkg/api"
 )
 
-// NewSubscriber returns a subscriber for the supplied feed.
-func NewSubscriber(api API, feed ActivityFeed) Subscriber {
+// newSubscriber returns a subscriber for the supplied feed.
+func newSubscriber(api API, feed ActivityFeed) Subscriber {
 	// Check the feed hubs for any subscription strategies we support
 	for _, hub := range feed.Hubs {
 		switch hub.Type {


### PR DESCRIPTION
This PR contains a few clean up items for the optimize-go client:
1. The activity item resource is brought inline with the current specification (no GET, PATCH instead of PUT, function names match operation IDs)
2. The `NewSubscriber` function is private to avoid confusion with `API.SubscribeActivity`
3. We can now use a more efficient HEAD request to get the activity feed URL
4. The API integration test had a deadlock because two sub-tests were interacting with the same unbuffered channel and only one was marked as "parallel". Also, a 30 second polling delay in a test _feels like a really long time_.