### PR TITLE
Fix URL construction

### DIFF
--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -148,8 +148,9 @@ func (h *httpAPI) GetApplication(ctx context.Context, u string) (Application, er
 }
 
 func (h *httpAPI) GetApplicationByName(ctx context.Context, n ApplicationName) (Application, error) {
-	u := h.client.URL(path.Join(h.endpoint, n.String())).String()
-	result, err := h.GetApplication(ctx, u)
+	u := h.client.URL(h.endpoint)
+	u.Path = path.Join(u.Path, n.String())
+	result, err := h.GetApplication(ctx, u.String())
 
 	// Improve the "not found" error message using the name
 	if eerr, ok := err.(*api.Error); ok && eerr.Type == ErrApplicationNotFound {
@@ -186,8 +187,9 @@ func (h *httpAPI) UpsertApplication(ctx context.Context, u string, app Applicati
 }
 
 func (h *httpAPI) UpsertApplicationByName(ctx context.Context, n ApplicationName, app Application) (api.Metadata, error) {
-	u := h.client.URL(path.Join(h.endpoint, n.String())).String()
-	return h.UpsertApplication(ctx, u, app)
+	u := h.client.URL(h.endpoint)
+	u.Path = path.Join(u.Path, n.String())
+	return h.UpsertApplication(ctx, u.String(), app)
 }
 
 func (h *httpAPI) DeleteApplication(ctx context.Context, u string) error {

--- a/pkg/api/experiments/v1alpha1/http.go
+++ b/pkg/api/experiments/v1alpha1/http.go
@@ -105,8 +105,9 @@ func (h *httpAPI) GetAllExperimentsByPage(ctx context.Context, u string) (Experi
 }
 
 func (h *httpAPI) GetExperimentByName(ctx context.Context, n ExperimentName) (Experiment, error) {
-	u := h.client.URL(path.Join(h.endpoint, n.String())).String()
-	exp, err := h.GetExperiment(ctx, u)
+	u := h.client.URL(h.endpoint)
+	u.Path = path.Join(u.Path, n.String())
+	exp, err := h.GetExperiment(ctx, u.String())
 
 	// Improve the "not found" error message using the name
 	if eerr, ok := err.(*api.Error); ok && eerr.Type == ErrExperimentNotFound {
@@ -142,8 +143,9 @@ func (h *httpAPI) GetExperiment(ctx context.Context, u string) (Experiment, erro
 }
 
 func (h *httpAPI) CreateExperimentByName(ctx context.Context, n ExperimentName, exp Experiment) (Experiment, error) {
-	u := h.client.URL(path.Join(h.endpoint, n.String())).String()
-	return h.CreateExperiment(ctx, u, exp)
+	u := h.client.URL(h.endpoint)
+	u.Path = path.Join(u.Path, n.String())
+	return h.CreateExperiment(ctx, u.String(), exp)
 }
 
 func (h *httpAPI) CreateExperiment(ctx context.Context, u string, exp Experiment) (Experiment, error) {


### PR DESCRIPTION
This PR ensures `path.Join` is only used on the path of the URL and not the entire URL.

Passing a fully qualified URL into `path.Join(...)` results in bad output, e.g.:
```
path.Join("http://example.com/foo", "bar") == "http:/example.com/foo/bar"
```
