### PR TITLE
Optimize Configuration Housekeeping

### DIFF
--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -79,8 +79,6 @@ type ApplicationServer struct {
 	BaseURL string `json:"base_url,omitempty"`
 	// AuthSuccessEndpoint is URL to direct the user to after a successful login.
 	AuthSuccessEndpoint string `json:"auth_success_endpoint,omitempty"`
-	// ExperimentsEndpoint is the URL of the experiments UI.
-	ExperimentsEndpoint string `json:"experiments_endpoint,omitempty"`
 }
 
 // NOTE: AuthorizationServer is defined by https://tools.ietf.org/html/rfc8414 do not add non-standard fields!

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -71,6 +71,8 @@ type APIServer struct {
 	ExperimentsEndpoint string `json:"experiments_endpoint,omitempty"`
 	// AccountsEndpoint is the URL of the accounts endpoint
 	AccountsEndpoint string `json:"accounts_endpoint,omitempty"`
+	// PerformanceTokenEndpoint is the URL of the Performance API token endpoint
+	PerformanceTokenEndpoint string `json:"performance_token_endpoint,omitempty"`
 }
 
 // ApplicationServer is the user facing application.

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -122,10 +122,6 @@ func defaultServerEndpoints(srv *Server) error {
 	if err != nil {
 		return err
 	}
-	base, err := applicationRoot(srv.Application.BaseURL)
-	if err != nil {
-		return err
-	}
 
 	// Apply the API defaults
 	defaultString(&srv.API.ApplicationsEndpoint, api+"/v2/applications/")
@@ -143,7 +139,6 @@ func defaultServerEndpoints(srv *Server) error {
 
 	// Apply the application defaults
 	defaultString(&srv.Application.AuthSuccessEndpoint, "https://docs.stormforge.io/api/auth_success/")
-	defaultString(&srv.Application.ExperimentsEndpoint, base+"/experiments")
 
 	// Special case for the registration service which is actually part of the accounts API
 	if u, err := url.Parse(srv.API.AccountsEndpoint); err != nil {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -66,22 +66,6 @@ func bootstrapClusterName() string {
 	return "default"
 }
 
-// applicationRoot returns the base URL of the UI.
-func applicationRoot(baseURL string) (base string, err error) {
-	b, err := url.Parse(baseURL)
-	if err != nil {
-		return "", err
-	}
-	if b.RawQuery != "" {
-		return "", fmt.Errorf("query component is not allowed: %s", baseURL)
-	}
-	if b.Fragment != "" {
-		return "", fmt.Errorf("fragment component is not allowed: %s", baseURL)
-	}
-	b.Path = strings.TrimRight(b.Path, "/")
-	return b.String(), nil
-}
-
 // defaultString overwrites an empty s1 with the value of s2
 func defaultString(s1 *string, s2 string) {
 	if *s1 == "" {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -127,6 +127,7 @@ func defaultServerEndpoints(srv *Server) error {
 	defaultString(&srv.API.ApplicationsEndpoint, api+"/v2/applications/")
 	defaultString(&srv.API.ExperimentsEndpoint, api+"/v1/experiments/")
 	defaultString(&srv.API.AccountsEndpoint, api+"/v1/accounts/")
+	defaultString(&srv.API.PerformanceTokenEndpoint, "https://app.stormforger.com/optimize/oauth/tokens")
 
 	// Apply the authorization defaults
 	// TODO We should try discovery, e.g. fetch `discovery.WellKnownURI(issuer, "oauth-authorization-server")` and _merge_ (not _default_ since the server reported values win)

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -50,7 +50,6 @@ func mergeServer(s1, s2 *Server) {
 	mergeString(&s1.Authorization.JSONWebKeySetURI, s2.Authorization.JSONWebKeySetURI)
 	mergeString(&s1.Application.BaseURL, s2.Application.BaseURL)
 	mergeString(&s1.Application.AuthSuccessEndpoint, s2.Application.AuthSuccessEndpoint)
-	mergeString(&s1.Application.ExperimentsEndpoint, s2.Application.ExperimentsEndpoint)
 }
 
 func mergeAuthorization(a1, a2 *Authorization) {


### PR DESCRIPTION
This PR contains two changes:
1. It removes the defunct UI experiment link configuration (no longer used in the product).
2. It adds configuration for the Performance Testing token exchange.
