### PR TITLE
Fix a panic when the option token source is nil

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -330,6 +331,9 @@ func (rsc *OptimizeConfig) PerformanceAuthorization(ctx context.Context) (tokene
 	ts, err := rsc.tokenSource(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if ts == nil {
+		return nil, fmt.Errorf("missing required authorization source")
 	}
 	sub := tokenexchange.OAuth2ExchangeTokenSource(ts)
 


### PR DESCRIPTION
If a configuration does not contain any authorization information, the resulting token source is `nil` (normally this would result in skipping OAuth2 for an HTTP transport, i.e. we just would not send an `Authorization` header). Since the point of the token exchange is that we need to start with an Optimize token we can just fail outright if the token is missing.