### PR TITLE
feat: Add Done() method for subscriber

### DIFF
--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -36,6 +36,8 @@ const (
 type Subscriber interface {
 	// Subscribe initiates a subscription that continues for the lifetime of the context.
 	Subscribe(ctx context.Context, ch chan<- ActivityItem)
+	// Done notifies the caller that the subscriber is finished and no longer running.
+	Done() <-chan struct{}
 }
 
 type API interface {


### PR DESCRIPTION
This adds a done method to the subscriber interface to allow signaling to callers
that the subscription is complete.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>