### PR TITLE
Blocking subscribe

### DIFF
--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -35,7 +35,7 @@ const (
 // Subscriber describes a strategy for subscribing to feed notifications.
 type Subscriber interface {
 	// Subscribe initiates a subscription that continues for the lifetime of the context.
-	Subscribe(ctx context.Context, ch chan<- ActivityItem)
+	Subscribe(ctx context.Context, ch chan<- ActivityItem) error
 }
 
 type API interface {

--- a/pkg/api/applications/v2/api_test.go
+++ b/pkg/api/applications/v2/api_test.go
@@ -155,7 +155,10 @@ func runTest(t *testing.T, td *apitest.ApplicationTestDefinition, appAPI applica
 				ps.PollInterval = 3 * time.Second
 			}
 
-			sub.Subscribe(subCtx, activity)
+			go func() {
+				err := sub.Subscribe(subCtx, activity)
+				require.NoError(t, err)
+			}()
 		})
 
 		var okScan, okRun bool


### PR DESCRIPTION
This PR makes the `Subscribe` call blocking (it returns an error), this ensures that errors from the API can be handled by the caller. It also gives the call the choice to run blocking or non-blocking (previously we forced non-blocking).