### PR TITLE
Change environment labels

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -75,15 +75,17 @@ func defaultString(s1 *string, s2 string) {
 
 func defaultServerRoots(env string, srv *Server) error {
 	// The environment corresponds to deployment details of the proprietary backend
-	switch env {
-	case "production":
+	switch strings.ToLower(env) {
+	case "production", "prod":
 		defaultString(&srv.Identifier, "https://api.stormforge.io/")
 		defaultString(&srv.Authorization.Issuer, "https://auth.stormforge.io/")
 		defaultString(&srv.Application.BaseURL, "https://app.stormforge.io/")
-	case "development":
+	case "staging", "stage":
 		defaultString(&srv.Identifier, "https://api.stormforge.dev/")
 		defaultString(&srv.Authorization.Issuer, "https://auth.stormforge.dev/")
 		defaultString(&srv.Application.BaseURL, "https://app.stormforge.dev/")
+	case "development", "dev":
+		return fmt.Errorf("unknown environment: '%s' (did you mean 'staging'?)", env)
 	default:
 		return fmt.Errorf("unknown environment: '%s'", env)
 	}


### PR DESCRIPTION
This PR makes the following changes to the supported environment labels:
1. Labels are now case-insensitive (i.e. "PRODUCTION" or "production" or "Production")
2. Short names are accepted (i.e. "prod" == "production")
3. The "development" label is temporarily deprecated in favor of "staging"
