### PR TITLE
Add a temporary migration from dev to stage

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -85,6 +85,7 @@ func defaultServerRoots(env string, srv *Server) error {
 		defaultString(&srv.Authorization.Issuer, "https://auth.stormforge.dev/")
 		defaultString(&srv.Application.BaseURL, "https://app.stormforge.dev/")
 	case environmentDevelopment:
+		// TODO Remove temporary migration and update validation when this gets fixed
 		return fmt.Errorf("unknown environment: '%s' (did you mean '%s'?)", env, environmentStaging)
 	default:
 		return fmt.Errorf("unknown environment: '%s'", env)

--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -49,6 +49,14 @@ func migrationLoader(cfg *OptimizeConfig) error {
 		return err
 	}
 
+	// TODO Remove this when we add development back in
+	if cfg.data.Environment == environmentDevelopment {
+		_ = cfg.Update(func(cfg *Config) error {
+			cfg.Environment = environmentStaging
+			return nil
+		})
+	}
+
 	return nil
 }
 

--- a/pkg/config/update.go
+++ b/pkg/config/update.go
@@ -101,9 +101,9 @@ func SetExecutionEnvironment(env string) Change {
 			case "staging", "stage":
 				env = environmentStaging
 			case "development", "dev":
-				env = environmentDevelopment
+				return fmt.Errorf("unknown environment: '%s' (did you mean '%s'?)", env, environmentStaging)
 			default:
-				return fmt.Errorf("unknown environment: %s", env)
+				return fmt.Errorf("unknown environment: '%s'", env)
 			}
 		}
 


### PR DESCRIPTION
Fix an issue where `env: development` in an existing config file would fail to validate.