### PR TITLE
 fix: Fix infinite recursion when unmarshaling scenario

### DIFF
--- a/pkg/api/applications/v2/scenario.go
+++ b/pkg/api/applications/v2/scenario.go
@@ -43,7 +43,10 @@ type ScenarioItem struct {
 	Scenario
 }
 
-func (l *ScenarioItem) UnmarshalJSON(b []byte) error { return api.UnmarshalJSON(b, l) }
+func (l *ScenarioItem) UnmarshalJSON(b []byte) error {
+	type t ScenarioItem
+	return api.UnmarshalJSON(b, (*t)(l))
+}
 
 type ScenarioList struct {
 	// The scenario list metadata.


### PR DESCRIPTION
This fixes a case where we try to unmarshal the scenario items and
after calling api unmarshal, we return back to scenario.unmarshal.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>