### PR TITLE
Add the development environment back in

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -85,8 +85,9 @@ func defaultServerRoots(env string, srv *Server) error {
 		defaultString(&srv.Authorization.Issuer, "https://auth.stormforge.dev/")
 		defaultString(&srv.Application.BaseURL, "https://app.stormforge.dev/")
 	case environmentDevelopment:
-		// TODO Remove temporary migration and update validation when this gets fixed
-		return fmt.Errorf("unknown environment: '%s' (did you mean '%s'?)", env, environmentStaging)
+		defaultString(&srv.Identifier, "https://api.dev-1.dev.gramlabs.dev/")
+		defaultString(&srv.Authorization.Issuer, "https://auth.dev-1.dev.gramlabs.dev/")
+		defaultString(&srv.Application.BaseURL, "https://app.dev-1.dev.gramlabs.dev/")
 	default:
 		return fmt.Errorf("unknown environment: '%s'", env)
 	}

--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -49,14 +49,6 @@ func migrationLoader(cfg *OptimizeConfig) error {
 		return err
 	}
 
-	// TODO Remove this when we add development back in
-	if cfg.data.Environment == environmentDevelopment {
-		_ = cfg.Update(func(cfg *Config) error {
-			cfg.Environment = environmentStaging
-			return nil
-		})
-	}
-
 	return nil
 }
 

--- a/pkg/config/update.go
+++ b/pkg/config/update.go
@@ -101,7 +101,7 @@ func SetExecutionEnvironment(env string) Change {
 			case "staging", "stage":
 				env = environmentStaging
 			case "development", "dev":
-				return fmt.Errorf("unknown environment: '%s' (did you mean '%s'?)", env, environmentStaging)
+				env = environmentDevelopment
 			default:
 				return fmt.Errorf("unknown environment: '%s'", env)
 			}


### PR DESCRIPTION
The PR reenstates the "development" environment label in the Optimize configuration.