### PR TITLE
Migrate "carbonrelay" domains

### DIFF
--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -241,10 +241,10 @@ func migrateCarbonRelayHostnames(cfg *OptimizeConfig) error {
 
 				u, err := url.Parse(*s)
 				if err != nil {
-					return err
-				}
-
-				if strings.Contains(u.Hostname(), ".carbonrelay.") {
+					// Silently ignore the error and try a direct string replacement instead
+					*s = strings.ReplaceAll(*s, ".carbonrelay.", ".stormforge.")
+				} else {
+					// For valid URLs, only replace the value in the host field
 					u.Host = strings.ReplaceAll(u.Host, ".carbonrelay.", ".stormforge.")
 					*s = u.String()
 				}


### PR DESCRIPTION
This PR scans all of the URLs in the configuration for ".carbonrelay." and updates it to ".stormforge." if necessary.