### PR TITLE
Application cluster output

### DIFF
--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -68,6 +68,7 @@ func main() {
 		command.NewGetApplicationsCommand(cfg, &printer{}),
 		command.NewGetExperimentsCommand(cfg, &printer{}),
 		command.NewGetTrialsCommand(cfg, &printer{}),
+		command.NewGetClustersCommand(cfg, &printer{}),
 	)
 
 	// Aggregate the DELETE commands

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/thestormforge/optimize-go
 go 1.18
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/lestrrat-go/jwx v1.0.6
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -32,6 +32,7 @@ const (
 	ErrActivityRateLimited    api.ErrorType = "activity-rate-limited"
 	ErrRecommendationInvalid  api.ErrorType = "recommendation-invalid"
 	ErrRecommendationNotFound api.ErrorType = "recommendation-not-found"
+	ErrClusterNotFound        api.ErrorType = "cluster-not-found"
 )
 
 // Subscriber describes a strategy for subscribing to feed notifications.
@@ -101,4 +102,13 @@ type API interface {
 	ListRecommendations(ctx context.Context, u string) (RecommendationList, error)
 	// PatchRecommendations updates recommendation configuration.
 	PatchRecommendations(ctx context.Context, u string, details RecommendationList) error
+
+	// GetCluster retrieves a cluster.
+	GetCluster(ctx context.Context, u string) (Cluster, error)
+	// ListClusters lists clusters.
+	ListClusters(ctx context.Context) (ClusterList, error)
+	// PatchCluster updates a cluster title.
+	PatchCluster(ctx context.Context, u string, c ClusterTitle) error
+	// DeleteCluster deletes a cluster.
+	DeleteCluster(ctx context.Context, u string) error
 }

--- a/pkg/api/applications/v2/application.go
+++ b/pkg/api/applications/v2/application.go
@@ -36,6 +36,7 @@ type ApplicationListQuery struct{ api.IndexQuery }
 
 type ApplicationItem struct {
 	Application
+	CreatedAt time.Time `json:"createdAt"`
 	// The number of scenarios associated with this application.
 	ScenarioCount   int                 `json:"scenarioCount,omitempty"`
 	LastDeployedAt  time.Time           `json:"lastDeployedAt,omitempty"`

--- a/pkg/api/applications/v2/application.go
+++ b/pkg/api/applications/v2/application.go
@@ -25,8 +25,10 @@ import (
 type Application struct {
 	api.Metadata `json:"-"`
 	Name         ApplicationName `json:"name"`
-	DisplayName  string          `json:"title,omitempty"`
+	DisplayName  string          `json:"title,omitempty"` // TODO This doesn't seem to get set
 	Resources    []interface{}   `json:"resources,omitempty"`
+	Cluster      string          `json:"cluster,omitempty"` // TODO This is write only?
+	CreatedAt    time.Time       `json:"createdAt"`
 }
 
 // NOTE: Use `DisplayName` as the field since `Title()` is a function on the embedded `Metadata`.
@@ -36,7 +38,6 @@ type ApplicationListQuery struct{ api.IndexQuery }
 
 type ApplicationItem struct {
 	Application
-	CreatedAt time.Time `json:"createdAt"`
 	// The number of scenarios associated with this application.
 	ScenarioCount   int                 `json:"scenarioCount,omitempty"`
 	LastDeployedAt  time.Time           `json:"lastDeployedAt,omitempty"`
@@ -62,5 +63,5 @@ type ApplicationList struct {
 	// The total number of items in the collection.
 	TotalCount int `json:"totalCount,omitempty"`
 	// The list of applications.
-	Applications []ApplicationItem `json:"applications,omitempty"`
+	Applications []ApplicationItem `json:"applications"`
 }

--- a/pkg/api/applications/v2/cluster.go
+++ b/pkg/api/applications/v2/cluster.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"time"
+
+	"github.com/thestormforge/optimize-go/pkg/api"
+)
+
+type Cluster struct {
+	api.Metadata           `json:"-"`
+	Name                   ClusterName `json:"name"`
+	CreatedAt              time.Time   `json:"created"`
+	OptimizeProVersion     string      `json:"optimizeProVersion,omitempty"`
+	OptimizeLiveVersion    string      `json:"optimizeLiveVersion,omitempty"`
+	PerformanceTestVersion string      `json:"performanceTestVersion,omitempty"`
+	KubernetesVersion      string      `json:"kubernetesVersion,omitempty"`
+	LastSeen               time.Time   `json:"lastSeen"`
+}
+
+type ClusterItem struct {
+	Cluster
+}
+
+func (ci *ClusterItem) UnmarshalJSON(b []byte) error {
+	type t ClusterItem
+	return api.UnmarshalJSON(b, (*t)(ci))
+}
+
+type ClusterList struct {
+	// The cluster list metadata.
+	api.Metadata `json:"-"`
+	// The total number of items in the collection.
+	TotalCount int `json:"totalCount,omitempty"`
+	// The list of clusters.
+	Items []ClusterItem `json:"items"`
+}
+
+type ClusterTitle struct {
+	Title string `json:"title"`
+}

--- a/pkg/api/applications/v2/naming.go
+++ b/pkg/api/applications/v2/naming.go
@@ -20,3 +20,8 @@ package v2
 type ApplicationName string
 
 func (n ApplicationName) String() string { return string(n) }
+
+// ClusterName represents a name token used to identify a cluster.
+type ClusterName string
+
+func (n ClusterName) String() string { return string(n) }

--- a/pkg/command/applications.go
+++ b/pkg/command/applications.go
@@ -64,6 +64,23 @@ func NewGetApplicationsCommand(cfg Config, p Printer) *cobra.Command {
 			}
 		}
 
+		for i := range result.Items {
+			if result.Items[i].Recommendations == applications.RecommendationsDisabled {
+				continue
+			}
+
+			u := result.Items[i].ApplicationItem.Link(api.RelationRecommendations)
+			if u == "" {
+				continue
+			}
+
+			rl, err := l.API.ListRecommendations(ctx, u)
+			if err != nil {
+				return err
+			}
+			result.Items[i].DeployInterval = rl.DeployConfiguration.Interval
+		}
+
 		return p.Fprint(out, result)
 	}
 

--- a/pkg/command/clusters.go
+++ b/pkg/command/clusters.go
@@ -1,0 +1,72 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/thestormforge/optimize-go/pkg/api"
+	applications "github.com/thestormforge/optimize-go/pkg/api/applications/v2"
+)
+
+func newClustersCommand(cfg Config) *cobra.Command {
+	return &cobra.Command{
+		Use:               "clusters [NAME ...]",
+		Aliases:           []string{"cluster"},
+		ValidArgsFunction: validClusterArgs(cfg),
+	}
+}
+
+// NewGetClustersCommand returns a command for getting clusters.
+func NewGetClustersCommand(cfg Config, p Printer) *cobra.Command {
+	cmd := newClustersCommand(cfg)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx, out := cmd.Context(), cmd.OutOrStdout()
+		client, err := api.NewClient(cfg.Address(), nil)
+		if err != nil {
+			return err
+		}
+
+		l := applications.Lister{
+			API: applications.NewAPI(client),
+		}
+
+		result := &ClusterOutput{Items: make([]ClusterRow, 0, len(args))}
+		if len(args) > 0 {
+			return fmt.Errorf("get cluster by name is not supported")
+		} else {
+			if err := l.ForEachCluster(ctx, result.Add); err != nil {
+				return err
+			}
+		}
+
+		return p.Fprint(out, result)
+	}
+
+	return cmd
+}
+
+// validClusterArgs returns shell completion logic for cluster names.
+func validClusterArgs(cfg Config) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := cmd.Context()
+		client, err := api.NewClient(cfg.Address(), nil)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		l := applications.Lister{
+			API: applications.NewAPI(client),
+		}
+
+		names := make([]string, 0, 16)
+		_ = l.ForEachCluster(ctx, func(item *applications.ClusterItem) error {
+			if name := item.Name.String(); strings.HasPrefix(name, toComplete) {
+				names = append(names, name)
+			}
+			return nil
+		})
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/pkg/command/output.go
+++ b/pkg/command/output.go
@@ -34,6 +34,23 @@ type Printer interface {
 	Fprint(out io.Writer, obj interface{}) error
 }
 
+// formatTime is a helper that returns empty strings for zero times and adds
+// support for a humanized format (if the layout is empty).
+func formatTime(t time.Time, layout string) string {
+	switch {
+	case t.IsZero():
+		return ""
+	case layout == "":
+		return humanize.Time(t)
+	default:
+		return t.Format(layout)
+	}
+}
+
+// NOTE: All the "*Row" structs have `json:"-"` for everything EXCEPT their
+// inline "*Item" field so when the row is marshalled as JSON it appears the
+// same as what the item would have been.
+
 // ApplicationRow is a table row representation of an application.
 type ApplicationRow struct {
 	Name                string `table:"name" csv:"name" json:"-"`
@@ -41,8 +58,8 @@ type ApplicationRow struct {
 	ScenarioCount       int    `table:"scenarios,wide" csv:"scenario_count" json:"-"`
 	RecommendationMode  string `table:"recommendations" csv:"recommendations" json:"-"`
 	DeployInterval      string `table:"deploy_interval" csv:"deploy_interval" json:"-"`
-	LastDeployedHuman   string `table:"last_deployed" csv:"-" json:"-"`
 	LastDeployedMachine string `table:"-" csv:"last_deployed" json:"-"`
+	LastDeployedHuman   string `table:"last_deployed" csv:"-" json:"-"`
 	Age                 string `table:"age,wide" csv:"-" json:"-"`
 
 	applications.ApplicationItem `table:"-" csv:"-"`
@@ -55,20 +72,14 @@ type ApplicationOutput struct {
 
 // Add an experiment item to the output.
 func (o *ApplicationOutput) Add(item *applications.ApplicationItem) error {
-	ldh, ldm := "", ""
-	if !item.LastDeployedAt.IsZero() {
-		ldh = humanize.Time(item.LastDeployedAt)
-		ldm = item.LastDeployedAt.Format(time.RFC3339)
-	}
-
 	o.Items = append(o.Items, ApplicationRow{
 		Name:                item.Name.String(),
 		DisplayName:         item.Title(),
 		ScenarioCount:       item.ScenarioCount,
 		RecommendationMode:  cases.Title(language.AmericanEnglish).String(string(item.Recommendations)),
-		LastDeployedHuman:   ldh,
-		LastDeployedMachine: ldm,
-		Age:                 humanize.Time(item.CreatedAt),
+		LastDeployedMachine: formatTime(item.LastDeployedAt, time.RFC3339),
+		LastDeployedHuman:   formatTime(item.LastDeployedAt, ""),
+		Age:                 formatTime(item.CreatedAt, ""),
 
 		ApplicationItem: *item,
 	})
@@ -154,5 +165,43 @@ func (o *TrialOutput) Add(item *experiments.TrialItem) error {
 		TrialItem: *item,
 	})
 
+	return nil
+}
+
+// ClusterRow is a table row representation of a cluster.
+type ClusterRow struct {
+	Name                   string `table:"name" csv:"name" json:"-"`
+	DisplayName            string `table:"Name,custom" json:"-"`
+	OptimizeProVersion     string `table:"optimize_pro" csv:"optimize_pro_version" json:"-"`
+	OptimizeLiveVersion    string `table:"optimize_live" csv:"optimize_live_version" json:"-"`
+	PerformanceTestVersion string `table:"performance_test,wide" csv:"performance_test_version" json:"-"`
+	KubernetesVersion      string `table:"kubernetes,wide" csv:"kubernetes_version" json:"-"`
+	LastSeenMachine        string `table:"-" csv:"last_seen" json:"-"`
+	LastSeenHuman          string `table:"last_seen" csv:"-" json:"-"`
+	Age                    string `table:"age,wide" csv:"-" json:"-"`
+
+	applications.ClusterItem `table:"-" csv:"-"`
+}
+
+// ClusterOutput wraps a cluster list for output.
+type ClusterOutput struct {
+	Items []ClusterRow `json:"items"`
+}
+
+// Add a cluster item to the output.
+func (o *ClusterOutput) Add(item *applications.ClusterItem) error {
+	o.Items = append(o.Items, ClusterRow{
+		Name:                   item.Name.String(),
+		DisplayName:            item.Title(),
+		OptimizeProVersion:     item.OptimizeProVersion,
+		OptimizeLiveVersion:    item.OptimizeLiveVersion,
+		PerformanceTestVersion: item.PerformanceTestVersion,
+		KubernetesVersion:      item.KubernetesVersion,
+		LastSeenMachine:        formatTime(item.LastSeen, time.RFC3339),
+		LastSeenHuman:          formatTime(item.LastSeen, ""),
+		Age:                    formatTime(item.CreatedAt, ""),
+
+		ClusterItem: *item,
+	})
 	return nil
 }


### PR DESCRIPTION
This tweaks a few things in the application (e.g. creation timestamp) and adds the cluster API.

Having the cluster API under `api/applications/v2` doesn't make a ton of sense; technically clusters are a top level resource (e.g. `/v2/clusters`). I think optimize-go is showing it's a age a little, at some point soon we might want to talk about rearranging the code (e.g. just have `api/v2` and `api/v1` and revisit how to reuse code for the `/v2/.../experiments` proxy).