### PR TITLE
Unauthorized hook

### DIFF
--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -46,7 +46,7 @@ func main() {
 				return err
 			}
 
-			http.DefaultTransport = cfg.Transport(cmd.Context(), http.DefaultTransport)
+			http.DefaultTransport = cfg.Transport(cfg.TokenSource(cmd.Context()), http.DefaultTransport)
 			return nil
 		},
 	}


### PR DESCRIPTION
This change adds a hook function to the optimize-go `Config` struct. If set, the function will be invoked whenever a 401 response is returned during token retrieval. Consumers can leverage this function to shutdown, e.g.:

```go
cfg.UnauthorizedFunc = func(err error) {
  ctx, cancel := context.WithTimeout(context.Background, 5 * time.Second)
  defer cancel()
  someLongRunningProcess.Shutdown(ctx)
  log.Fatal().Err(err).Msg("Unable to obtain StormForge API authorization")
}
```

The goal of exposing this function is prevent zombies from attacking the token endpoint. Because it is October. And that is when zombies attack.

Additionally, the "alternate subject" function has been replaced by a generic endpoint parameters map. The signature of the `Transport` function has also changed to facilitate the single creation of an `oauth2.TokenSource` as we should not be creating multiple token sources during the lifetime of a program (noted in comments).