### PR TITLE
Limit request ratio

### DIFF
--- a/pkg/api/applications/v2/recommendation.go
+++ b/pkg/api/applications/v2/recommendation.go
@@ -84,6 +84,7 @@ type ContainerResources struct {
 	TargetUtilization *ResourceList `json:"targetUtilization,omitempty"`
 	Tolerance         *ResourceList `json:"tolerance,omitempty"`
 	Bounds            *Bounds       `json:"bounds,omitempty"`
+	LimitRequestRatio *ResourceList `json:"limitRequestRatio,omitempty"`
 }
 
 type Bounds struct {

--- a/pkg/api/numorstr_test.go
+++ b/pkg/api/numorstr_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"math"
 	"math/big"
 	"testing"
 
@@ -167,6 +168,12 @@ func TestNumberOrString_Float64Value(t *testing.T) {
 			value:    FromString("1"),
 			expected: 1.0,
 		},
+
+		{
+			desc:     "infinity",
+			value:    FromValue("infinity"),
+			expected: math.Inf(1),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -292,6 +299,9 @@ func TestNumberOrString_Quantity(t *testing.T) {
 		{value: "1T", expected: 1000000000000},
 		{value: "1P", expected: 1000000000000000},
 		{value: "1E", expected: 1000000000000000000},
+
+		// These are out of spec
+		{value: "+Inf", expected: math.Inf(1)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.value, func(t *testing.T) {


### PR DESCRIPTION
This PR adds the limit request ratio configuration to Optimize Go and the CLI.

The `NumberOrString` representation of infinity will effectively marshal to JSON as a string like `"+Inf"` (basically exactly what the numeric formatter produces, just as an explicit JSON string). Parsing accepts a slightly wider set of values (e.g. `"infinity"`), again this all just through the stock numeric libraries in Go.