### PR TITLE
Add logic for passing a correct activity patch request body

### DIFF
--- a/pkg/api/applications/v2/activity.go
+++ b/pkg/api/applications/v2/activity.go
@@ -108,8 +108,7 @@ type RefreshActivity struct {
 }
 
 type ActivityPatchRequest struct {
-	Title string   `json:"title"`
-	Tags  []string `json:"tags"`
+	Title string `json:"title"`
 	// Data is a JSON-serializable value for internal metadata about the Activity
 	Data any `json:"_stormforge,omitempty"`
 }

--- a/pkg/api/applications/v2/activity.go
+++ b/pkg/api/applications/v2/activity.go
@@ -110,7 +110,8 @@ type RefreshActivity struct {
 type ActivityPatchRequest struct {
 	Title string   `json:"title"`
 	Tags  []string `json:"tags"`
-	Data  any      `json:"_stormforge,omitempty"`
+	// Data is a JSON-serializable value for internal metadata about the Activity
+	Data any `json:"_stormforge,omitempty"`
 }
 
 type ActivityFailure struct {

--- a/pkg/api/applications/v2/activity.go
+++ b/pkg/api/applications/v2/activity.go
@@ -107,6 +107,12 @@ type RefreshActivity struct {
 	ActivityFailure
 }
 
+type ActivityPatchRequest struct {
+	Title string   `json:"title"`
+	Tags  []string `json:"tags"`
+	Data  any      `json:"_stormforge,omitempty"`
+}
+
 type ActivityFailure struct {
 	FailureReason  string `json:"failure_reason,omitempty"`
 	FailureMessage string `json:"failure_message,omitempty"`

--- a/pkg/api/applications/v2/api.go
+++ b/pkg/api/applications/v2/api.go
@@ -99,7 +99,7 @@ type API interface {
 	// DeleteActivity resolves application activity.
 	DeleteActivity(ctx context.Context, u string) error
 	// PatchApplicationActivity updates application activity.
-	PatchApplicationActivity(ctx context.Context, u string, a ActivityFailure) error
+	PatchApplicationActivity(ctx context.Context, u string, a ActivityPatchRequest) error
 
 	// SubscribeActivity returns a subscriber for the activity feed.
 	SubscribeActivity(ctx context.Context, q ActivityFeedQuery) (Subscriber, error)

--- a/pkg/api/applications/v2/http.go
+++ b/pkg/api/applications/v2/http.go
@@ -592,7 +592,7 @@ func (h *httpAPI) DeleteActivity(ctx context.Context, u string) error {
 	}
 }
 
-func (h *httpAPI) PatchApplicationActivity(ctx context.Context, u string, a ActivityFailure) error {
+func (h *httpAPI) PatchApplicationActivity(ctx context.Context, u string, a ActivityPatchRequest) error {
 	req, err := httpNewJSONRequest(http.MethodPatch, u, a)
 	if err != nil {
 		return err


### PR DESCRIPTION
Based on the expected request body for the patch activity endpoint: https://github.com/gramLabs/application-service/blob/main/internal/api/v2/activity.go#L180-L184

We need to pass a value like the following to correctly set the failure reason and failure message:

```json
{
  "_stormforge": {
    "failure_reason": "code-1",
    "failure_message": "Something broke"
  }
}
```

After this change, consumers of `PatchApplicationActivity` will make a call like this to set the values:

```go
body := applications.ActivityPatchRequest{
	Data: applications.ActivityFailure{FailureReason: reason, FailureMessage: msg}
}

if err := a.client.PatchApplicationActivity(ctx, u, body); err != nil {
	logger.Error(err, "Failed to update application activity")
}
```

This will allow the patch endpoint to store the data about activity failures. Also, consumers could now use this API to also se the title or tags on an activity, since the endpoint already supports these values on the request body.